### PR TITLE
feat(golang/autodiscovery): Golang autodiscovery cleanup

### DIFF
--- a/updatecli/policies/golang/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/golang/autodiscovery/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.3.0
+
+* By default don't enable scm
+* Rename autodiscovery params version `.golang.gomod.spec` to `.spec`
+
+## 0.2.0
+
+* Don't try to detect branch automatically
+
+## 0.1.0
+
+* Init policy

--- a/updatecli/policies/golang/autodiscovery/Policy.yaml
+++ b/updatecli/policies/golang/autodiscovery/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/autodiscovery/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/autodiscovery/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
@@ -16,7 +16,7 @@ autodiscovery:
 
   crawlers:
     golang/gomod:
-{{ .golang.gomod.spec | toYaml | indent 6 }}
+{{ .spec | toYaml | indent 6 }}
 
 {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
 scms:

--- a/updatecli/policies/golang/autodiscovery/values.yaml
+++ b/updatecli/policies/golang/autodiscovery/values.yaml
@@ -2,15 +2,13 @@ pipelineid: golang
 automerge: false
 
 scm:
-  enabled: true
+  enabled: false
   user: updatecli-bot
-  email: updatecli-bot@updatecli.io
-  owner: updatecli
-  repository: updatecli
-  #token: "xxx"
-  username: "updatecli-bot"
+  # email: updatecli-bot@updatecli.io
+  # owner: updatecli
+  # repository: updatecli
+  # token: "xxx"
+  # username: "updatecli-bot"
   branch: main
 
-golang:
-  gomod:
-    spec:
+spec:


### PR DESCRIPTION
* By default don't enable scm
* Rename autodiscovery params version `.golang.gomod.spec` to `.spec`

## Description

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
