### PR TITLE
feat(updatecli): add policy to update githubaction

### DIFF
--- a/updatecli/policies/updatecli/githubaction/CHANGELOG.md
+++ b/updatecli/policies/updatecli/githubaction/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+* Introduce a new version of the policy

--- a/updatecli/policies/updatecli/githubaction/Policy.yaml
+++ b/updatecli/policies/updatecli/githubaction/Policy.yaml
@@ -1,0 +1,14 @@
+authors:
+  - Olblak <me@olblak.com>
+
+url: "https://github.com/updatecli/policies/"
+documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/githubaction/README.md"
+source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/githubaction/"
+version: 0.1.0
+vendor: Updatecli Project
+
+licenses:
+  - "Apache-2.0 license"
+
+description: |
+  Automatically update the Updatecli version used by GitHub action workflows.

--- a/updatecli/policies/updatecli/githubaction/README.md
+++ b/updatecli/policies/updatecli/githubaction/README.md
@@ -1,0 +1,3 @@
+# README
+
+This policy updates GitHub Action workflows with the latest Updatecli version

--- a/updatecli/policies/updatecli/githubaction/testdata/values.yaml
+++ b/updatecli/policies/updatecli/githubaction/testdata/values.yaml
@@ -1,0 +1,10 @@
+scm:
+  enabled: true
+  user: updatecli-bot
+  email: updatecli-bot@updatecli.io
+  owner: updatecli
+  repository: website
+  username: "updatecli-bot"
+  branch: master
+
+versionpattern: ">=0.0.0-0"

--- a/updatecli/policies/updatecli/githubaction/updatecli.d/action-version.yaml
+++ b/updatecli/policies/updatecli/githubaction/updatecli.d/action-version.yaml
@@ -1,0 +1,68 @@
+---
+# Helpers
+# {{ $GitHubUser := env "GITHUB_ACTOR"}}
+# {{ $GitHubRepositoryList := env "GITHUB_REPOSITORY" | split "/"}}
+# {{ $GitHubPAT := env "GITHUB_TOKEN"}}
+# {{ $GitHubUsername := env "GITHUB_ACTOR"}}}
+
+name : 'deps: Updatecli version used by GitHub action'
+pipelineid: '{{ .pipelineid }}'
+
+# Only enable the scm section if Updatecli is executed from a Github Action
+# {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
+actions:
+    default:
+        title: 'deps: bump Updatecli version to {{ source "updatecli" }}'
+        kind: "github/pullrequest"
+        spec:
+            automerge: {{ .automerge }}
+            labels:
+                - "chore"
+                - "dependencies"
+            mergemethod: "squash"
+        scmid: "default"
+
+scms:
+    default:
+        kind: "github"
+        spec:
+            # Priority set to the environment variable
+            user: '{{ default $GitHubUser .scm.user }}'
+            email: '{{ .scm.email }}'
+            owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
+            repository: '{{ default $GitHubRepositoryList._1 .scm.repository }}'
+            token: '{{ default $GitHubPAT .scm.token }}'
+            username: '{{ default $GitHubUsername .scm.username }}'
+            branch: '{{ .scm.branch }}'
+# {{ end }}
+
+sources:
+    updatecli:
+        name: "Get latest Updatecli version"
+        kind: "githubrelease"
+        spec:
+            owner: "updatecli"
+            repository: "updatecli"
+            token: '{{ default .scm.token $GitHubPAT }}'
+            username: '{{ default .scm.username $GitHubUsername }}'
+            versionfilter:
+                kind: "semver"
+                pattern: '{{ .versionpattern }}'
+
+targets:
+    githubaction:
+        name: 'deps: update Updatecli used by Github Action to {{ source "updatecli" }}'
+        kind: yaml
+        spec:
+            engine: yamlpath 
+            key: '$.jobs.*.steps[?(@.uses =~ /^updatecli\/updatecli-action/)].with.version'
+            files:
+             - '.github/workflows/*'
+            searchpattern: true
+# Only enable the scm section if Updatecli is executed from a Github Action
+# {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
+        scmid: default
+# {{ end }}
+
+# Represent the minimum version of Updatecli required to run this policy
+version: v0.68.0

--- a/updatecli/policies/updatecli/githubaction/updatecli.d/action.yaml
+++ b/updatecli/policies/updatecli/githubaction/updatecli.d/action.yaml
@@ -1,0 +1,70 @@
+---
+# Helpers
+# {{ $GitHubUser := env "GITHUB_ACTOR"}}
+# {{ $GitHubRepositoryList := env "GITHUB_REPOSITORY" | split "/"}}
+# {{ $GitHubPAT := env "GITHUB_TOKEN"}}
+# {{ $GitHubUsername := env "GITHUB_ACTOR"}}}
+
+name : 'deps: bump Updatecli GH action'
+pipelineid: '{{ .pipelineid }}'
+
+# Only enable the scm section if Updatecli is executed from a Github Action
+# {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
+actions:
+    default:
+        title: 'deps: bump Updatecli GitHub action to {{ source "updatecli" }}'
+        kind: "github/pullrequest"
+        spec:
+            automerge: {{ .automerge }}
+            labels:
+                - "chore"
+                - "dependencies"
+            mergemethod: "squash"
+        scmid: "default"
+
+scms:
+    default:
+        kind: "github"
+        spec:
+            # Priority set to the environment variable
+            user: '{{ default $GitHubUser .scm.user }}'
+            email: '{{ .scm.email }}'
+            owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
+            repository: '{{ default $GitHubRepositoryList._1 .scm.repository }}'
+            token: '{{ default $GitHubPAT .scm.token }}'
+            username: '{{ default $GitHubUsername .scm.username }}'
+            branch: '{{ .scm.branch }}'
+# {{ end }}
+
+sources:
+    updatecli:
+        name: "Get latest Updatecli version"
+        kind: "githubrelease"
+        spec:
+            owner: "updatecli"
+            repository: "updatecli-action"
+            token: '{{ default .scm.token $GitHubPAT }}'
+            username: '{{ default .scm.username $GitHubUsername }}'
+            versionfilter:
+                kind: "semver"
+                pattern: '{{ .versionpattern }}'
+
+targets:
+    githubaction:
+        name: 'deps: update Updatecli used by Github Action to {{ source "updatecli" }}'
+        kind: yaml
+        disablesourceinput: true
+        spec:
+            engine: yamlpath 
+            key: '$.jobs.*.steps[?(@.uses =~ /^updatecli\/updatecli-action/)].uses'
+            value: 'updatecli/updatecli-action@{{ source "updatecli" }}'
+            files:
+             - '.github/workflows/*'
+            searchpattern: true
+# Only enable the scm section if Updatecli is executed from a Github Action
+# {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
+        scmid: default
+# {{ end }}
+
+# Represent the minimum version of Updatecli required to run this policy
+version: v0.68.0

--- a/updatecli/policies/updatecli/githubaction/values.yaml
+++ b/updatecli/policies/updatecli/githubaction/values.yaml
@@ -1,0 +1,14 @@
+pipelineid: updatecli
+automerge: false
+
+scm:
+  enabled: false
+  # user: updatecli-bot
+  # email: updatecli-bot@updatecli.io
+  # owner: updatecli
+  # repository: website
+  # #token: "xxx"
+  # username: "updatecli-bot"
+  # branch: main
+
+versionpattern: "*"


### PR DESCRIPTION
## Description
Add a policy to automate Updatecli github action.
It supports updating both the updatecli version and the updatecli-action version 

## Test

To test this pull request, you can run the following commands:

```shell
updatecli diff --config updatecli/policies/updatecli/githubaction/updatecli.d/ --values updatecli/policies/updatecli/githubaction/values.yaml --values updatecli/policies/updatecli/githubaction/testdata/values.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
