### PR TITLE
feat: add customization to golang autodiscovery policy

### DIFF
--- a/updatecli/policies/golang/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/golang/autodiscovery/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0
+
+* Allow to set pipeline name using `name`
+* Allow to set pipelineid using `pipelineid`
+
 ## 0.5.0
 
 * Set action title based on groupby parameter

--- a/updatecli/policies/golang/autodiscovery/Policy.yaml
+++ b/updatecli/policies/golang/autodiscovery/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/autodiscovery/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/autodiscovery/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
@@ -5,7 +5,8 @@
 # {{ $GitHubPAT := env "GITHUB_TOKEN"}}
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
-name: "deps(golang): Bump all dependencies"
+name: '{{ .name }}'
+pipelineid: '{{ .pipelineid }}'
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/golang/autodiscovery/values.yaml
+++ b/updatecli/policies/golang/autodiscovery/values.yaml
@@ -1,4 +1,5 @@
-pipelineid: golang
+name: 'deps(golang): Bump all dependencies'
+pipelineid: golang/autodiscovery/all
 automerge: false
 
 scm:


### PR DESCRIPTION
This pullrquest allows to customize both the name and pipelinid of the golang autodiscovery plugin
## Description

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
/
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
