### PR TITLE
feat: add golang version policy

### DIFF
--- a/updatecli/policies/golang/version/CHANGELOG.md
+++ b/updatecli/policies/golang/version/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+* Init policy

--- a/updatecli/policies/golang/version/Policy.yaml
+++ b/updatecli/policies/golang/version/Policy.yaml
@@ -1,0 +1,14 @@
+authors:
+  - Olblak <me@olblak.com>
+
+url: "https://github.com/updatecli/policies/"
+documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/version/README.md"
+source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/version/"
+version: 0.1.0
+vendor: Updatecli Project
+
+licenses:
+  - "Apache-2.0 license"
+
+description: |
+  Golang Version update policy

--- a/updatecli/policies/golang/version/README.md
+++ b/updatecli/policies/golang/version/README.md
@@ -1,0 +1,3 @@
+# README 
+
+This policy tries to detected available Golang version update both in go.mod and GitHub action workflows

--- a/updatecli/policies/golang/version/testdata/values.yaml
+++ b/updatecli/policies/golang/version/testdata/values.yaml
@@ -1,0 +1,9 @@
+scm:
+  enabled: true
+  user: updatecli-bot
+  email: updatecli-bot@updatecli.io
+  owner: updatecli
+  repository: udash
+  username: "updatecli-bot"
+  branch: main
+

--- a/updatecli/policies/golang/version/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/version/updatecli.d/default.tpl
@@ -1,0 +1,63 @@
+---
+# Helpers
+# {{ $GitHubUser := env ""}}
+# {{ $GitHubRepositoryList := env "GITHUB_REPOSITORY" | split "/"}}
+# {{ $GitHubPAT := env "GITHUB_TOKEN"}}
+# {{ $GitHubUsername := env "GITHUB_ACTOR"}}
+
+name: '{{ .name }}'
+pipelineid: '{{ .pipelineid }}'
+
+sources:
+    golang:
+        name: Get latest Golang version
+        kind: golang
+
+targets:
+    go.mod:
+        name: 'deps(gomod): Bump Golang version to {{ source "golang" }}'
+        kind: golang/gomod
+#{{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
+        scmid: default
+# {{ end }}
+        sourceid: golang
+
+    github-action:
+        name: 'deps(github-action): Bump Golang version to {{ source "golang" }}'
+        kind: yaml
+        spec:
+            engine: yamlpath    
+            files:
+              - '.github/workflows/*'
+            key: '$.jobs.build.steps[?(@.uses =~ /^actions\/setup-go/)].with.go-version'
+            searchpattern: true
+#{{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
+        scmid: default
+# {{ end }}
+        sourceid: golang
+
+{{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
+scms:
+  default:
+    kind: "github"
+    spec:
+      # Priority set to the environment variable
+      user: '{{ default $GitHubUser .scm.user}}'
+      email: '{{ .scm.email }}'
+      owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
+      repository: '{{ default $GitHubRepositoryList._1 .scm.repository}}'
+      token: '{{ default $GitHubPAT .scm.token }}'
+      username: '{{ default $GitHubUsername .scm.username }}'
+      branch: '{{ .scm.branch }}'
+
+actions:
+  default:
+    title: 'deps: Bump Golang version to {{ source "golang" }}'
+    kind: "github/pullrequest"
+    spec:
+      automerge: {{ .automerge }}
+      labels:
+         - dependencies
+    scmid: "default"
+{{ end }}
+

--- a/updatecli/policies/golang/version/values.yaml
+++ b/updatecli/policies/golang/version/values.yaml
@@ -1,0 +1,14 @@
+name: 'deps: Bump Golang version'
+pipelineid: golang/version
+automerge: false
+
+scm:
+  enabled: false
+  # user: updatecli-bot
+  # email: updatecli-bot@updatecli.io
+  # owner: updatecli
+  # repository: updatecli
+  # token: "xxx"
+  # username: "updatecli-bot"
+  # branch: main
+


### PR DESCRIPTION
Add a policy to detected available Golang version update both in go.mod and GitHub action workflows

## Description

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
updatecli diff --config updatecli/policies/golang/version/updatecli.d --values updatecli/policies/golang/version/values.yaml --values updatecli/policies/golang/version/testdata/values.yaml
make test 
make e2e-test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
