### PR TITLE
feat: add golangci-lint policy

### DIFF
--- a/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
+++ b/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.1.0
+
+  * Initial release

--- a/updatecli/policies/golangci-lint/githubaction/Policy.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/Policy.yaml
@@ -1,0 +1,14 @@
+authors:
+  - Olblak <me@olblak.com>
+
+url: "https://github.com/updatecli/policies/"
+documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golangci-lint/githubaction/README.md"
+source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golangci-lint/githubaction/"
+version: 0.1.0
+vendor: Updatecli Project
+
+licenses:
+  - "Apache-2.0 license"
+
+description: |
+  Automatically update GitHub action workflows with the latest golangci-lint version.

--- a/updatecli/policies/golangci-lint/githubaction/README.md
+++ b/updatecli/policies/golangci-lint/githubaction/README.md
@@ -1,0 +1,71 @@
+# README
+
+## DESCRIPTION
+
+Automatically update GitHub action workflows with the latest golangci-lint version.
+
+## HOW TO USE
+
+**Show**
+
+They are two different approaches to see the content of this policy:
+
+Using the policy from the local filesystem by running:
+
+	updatecli manifest show --config updatecli.d --values values.d/default.yaml
+
+Using the policy from the registry by running:
+
+    updatecli manifest show $OCI_REGISTRY/< insert your policy name>:v0.1.0
+
+
+**Use**
+
+Similarly to the show command, they are two ways to execute an Updatecli policy, either using the local file or the one stored on the registry.
+
+Using the policy from the local filesystem by running:
+
+    updatecli diff --config updatecli.d --values values.d/default.yaml
+
+Using the policy from the registry by running:
+
+    updatecli diff ghcr.io/updatecli/policies/<a policy name>:v0.1.0
+
+
+If "diff" is replaced by "apply", then the policy will be executed in enforce mode.
+
+⚠ Any values files specified at runtime will override default values set from the policy bundle
+
+**Login**
+
+Regardless your Updatecli policy is meant to be public or private, you probably always want to be authenticated with your registry, by running:
+
+    docker login "$OCI_REGISTRY"
+
+INFO: OCI_REGISTRY can be any OCI compliant registry such as [Zot](https://github.com/project-zot/zot), [DockerHub](https://hub.docker.com), [ghcr.io](https://ghcr.io),etc.
+
+**Publish**
+
+Policies defines in this repository can be published to your registry by running:
+
+	updatecli manifest push \
+		--config updatecli.d \
+		--values values.d/default.yaml \
+    	--policy Policy.yaml \
+    	--tag "$OCI_REGISTRY/<insert your policy name>" \
+		.
+
+⚠ The tag is defined by the version field in the policy file
+⚠ The latest tag always represents the latest version published from
+a semantic versioning point of view.
+
+## NEXT STEPS
+
+Feel free to look on the [Updatecli documentation](https://updatecli.io) to learn more about how to use Updatecli.
+
+Another good starting point is to understand how to use [update-compose.yaml](https://www.updatecli.io/docs/core/compose/) to orchestrate multiple Updatecli policies.
+
+## CONTRIBUTING
+
+This document has been generated from this [template](https://github.com/updatecli/updatecli/blob/main/pkg/core/scaffold/readme.go).
+Feel free to suggest any improvements or open an [issue](https://github.com/updatecli/updatecli/issues).

--- a/updatecli/policies/golangci-lint/githubaction/testdata/values.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/testdata/values.yaml
@@ -1,0 +1,9 @@
+scm:
+  enabled: true
+  user: updatecli
+  email: bot@updatecli.io
+  owner: updatecli
+  repository: updatecli
+  username: "updatecli-bot"
+  branch: main
+

--- a/updatecli/policies/golangci-lint/githubaction/updatecli.d/default.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/updatecli.d/default.yaml
@@ -1,0 +1,68 @@
+---
+# Helpers
+# {{ $GitHubUser := env "GITHUB_ACTOR"}}
+# {{ $GitHubRepositoryList := env "GITHUB_REPOSITORY" | split "/"}}
+# {{ $GitHubPAT := env "GITHUB_TOKEN"}}
+# {{ $GitHubUsername := env "GITHUB_ACTOR"}}}
+
+name : '{{ .name }}'
+pipelineid: '{{ .pipelineid }}'
+
+# Only enable the scm section if Updatecli is executed from a Github Action
+# {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
+actions:
+    default:
+        title: 'deps: bump golangci-lint to {{ source "golangci-lint" }}'
+        kind: "github/pullrequest"
+        spec:
+            automerge: {{ .automerge }}
+            labels:
+                - "chore"
+                - "dependencies"
+            mergemethod: "squash"
+        scmid: "default"
+
+scms:
+    default:
+        kind: "github"
+        spec:
+            # Priority set to the environment variable
+            user: '{{ default $GitHubUser .scm.user }}'
+            email: '{{ .scm.email }}'
+            owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
+            repository: '{{ default $GitHubRepositoryList._1 .scm.repository }}'
+            token: '{{ default $GitHubPAT .scm.token }}'
+            username: '{{ default $GitHubUsername .scm.username }}'
+            branch: '{{ .scm.branch }}'
+# {{ end }}
+
+sources:
+    golangci-lint:
+        name: "Get latest Updatecli version"
+        kind: "githubrelease"
+        spec:
+            owner: "golangci"
+            repository: "golangci-lint"
+            token: '{{ default .scm.token $GitHubPAT }}'
+            username: '{{ default .scm.username $GitHubUsername }}'
+            versionfilter:
+                kind: "semver"
+                pattern: '{{ .versionpattern }}'
+
+targets:
+    githubaction:
+        name: 'deps: bump golangci-lint in GitHub Action to {{ source "golangci-lint" }}'
+        kind: yaml
+        spec:
+            engine: yamlpath 
+            key: '$.jobs.*.steps[?(@.uses =~ /^golangci\/golangci-lint-action/)].with.version'
+            files:
+             - '.github/workflows/*'
+            searchpattern: true
+# Only enable the scm section if Updatecli is executed from a Github Action
+# {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
+        scmid: default
+# {{ end }}
+
+# Represent the minimum version of Updatecli required to run this policy
+version: v0.68.0

--- a/updatecli/policies/golangci-lint/githubaction/values.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/values.yaml
@@ -1,0 +1,17 @@
+pipelineid: golangci-lint
+automerge: false
+
+scm:
+  enabled: false
+  # user: updatecli-bot
+  # email: updatecli-bot@updatecli.io
+  # owner: updatecli
+  # repository: website
+  # #token: "xxx"
+  # username: "updatecli-bot"
+  # branch: main
+
+name: 'deps: Updatecli version used by GitHub action'
+
+versionpattern: "*"
+


### PR DESCRIPTION
Add policy for Automatically updating GitHub action workflows with the latest golangci-lint version.

## Description

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
updatecli diff --config updatecli/policies/golangci-lint/githubaction/updatecli.d/ --values updatecli/policies/golangci-lint/githubaction/values.yaml --values updatecli/policies/golangci-lint/githubaction/testdata/values.yaml

make test
make e2e-test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
