### PR TITLE
feat: By default undefine pipelineid for autodiscovery policies

### DIFF
--- a/updatecli/policies/autodiscovery/all/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/all/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Changelog 
 
-# 0.4.0
+## 0.5.0
+
+* By default undefined pipelineid
+
+## 0.4.0
 
 * Allow to override pipeline name
 
-# 0.3.0
+## 0.3.0
 
 * Swap default order for scm configuration to use environment variable if nothing else is defined
 
-# 0.2.0
+## 0.2.0
 
-# 0.1.0
+## 0.1.0
 
 * Init policy

--- a/updatecli/policies/autodiscovery/all/Policy.yaml
+++ b/updatecli/policies/autodiscovery/all/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/all/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/all/"
-version: 0.4.0
+version: 0.5.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/all/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/all/updatecli.d/default.tpl
@@ -1,6 +1,10 @@
 ---
 name: '{{ .name }}'
 
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
+
 autodiscovery:
   groupby: {{ .autodiscovery.groupby }}
 {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}

--- a/updatecli/policies/autodiscovery/all/values.yaml
+++ b/updatecli/policies/autodiscovery/all/values.yaml
@@ -1,5 +1,7 @@
 name: 'deps: Bump all dependencies'
 
+#pipelineid: all
+
 autodiscovery:
   groupby: all
 

--- a/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* By default undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/cargo/Policy.yaml
+++ b/updatecli/policies/autodiscovery/cargo/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/cargo/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/cargo/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/cargo/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/cargo/updatecli.d/default.tpl
@@ -6,14 +6,16 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}
 #{{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
   scmid: default
   actionid: default
-# {{ end }}
+#{{ end }}
 
   crawlers:
     cargo:

--- a/updatecli/policies/autodiscovery/cargo/values.yaml
+++ b/updatecli/policies/autodiscovery/cargo/values.yaml
@@ -1,6 +1,6 @@
 name: "deps(cargo): bump all policies"
 
-pipelineid: cargo/autodiscovery
+# pipelineid: cargo/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/dockercompose/Policy.yaml
+++ b/updatecli/policies/autodiscovery/dockercompose/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockercompose/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockercompose/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/dockercompose/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/dockercompose/updatecli.d/default.tpl
@@ -6,14 +6,16 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}
 #{{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
   scmid: default
   actionid: default
-# {{ end }}
+#{{ end }}
 
   crawlers:
     dockercompose:

--- a/updatecli/policies/autodiscovery/dockercompose/values.yaml
+++ b/updatecli/policies/autodiscovery/dockercompose/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(dockercompose): bump dependencies"
-pipelineid: dockercompose/autodiscovery
+# pipelineid: dockercompose/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/dockerfile/Policy.yaml
+++ b/updatecli/policies/autodiscovery/dockerfile/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockerfile/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockerfile/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/dockerfile/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/dockerfile/updatecli.d/default.tpl
@@ -6,14 +6,16 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}
 #{{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
   scmid: default
   actionid: default
-# {{ end }}
+#{{ end }}
 
   crawlers:
     dockerfile:

--- a/updatecli/policies/autodiscovery/dockerfile/values.yaml
+++ b/updatecli/policies/autodiscovery/dockerfile/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(dockerfile): bump all dependencies"
-pipelineid: dockerfile/autodiscovery
+#pipelineid: dockerfile/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/flux/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/flux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/flux/Policy.yaml
+++ b/updatecli/policies/autodiscovery/flux/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/flux/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/flux/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/flux/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/flux/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/flux/values.yaml
+++ b/updatecli/policies/autodiscovery/flux/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(flux): bump all dependencies"
-pipelineid: flux/autodiscovery
+#pipelineid: flux/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/golang/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/golang/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+* By default, undefined pipelineid
+
 ## 0.6.0
 
 * Allow to set pipeline name using `name`

--- a/updatecli/policies/autodiscovery/golang/Policy.yaml
+++ b/updatecli/policies/autodiscovery/golang/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/golang/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/golang/"
-version: 0.6.0
+version: 0.7.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/golang/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/golang/updatecli.d/default.tpl
@@ -6,14 +6,16 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
+#{{ if .pipelineid }}
 pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}
 #{{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
   scmid: default
   actionid: default
-# {{ end }}
+#{{ end }}
 
   crawlers:
     golang/gomod:

--- a/updatecli/policies/autodiscovery/golang/values.yaml
+++ b/updatecli/policies/autodiscovery/golang/values.yaml
@@ -1,5 +1,5 @@
 name: 'deps(golang): Bump all dependencies'
-pipelineid: golang/autodiscovery
+#pipelineid: golang/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/helm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.3.0
+
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/helm/Policy.yaml
+++ b/updatecli/policies/autodiscovery/helm/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helm/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helm/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/helm/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/helm/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/helm/values.yaml
+++ b/updatecli/policies/autodiscovery/helm/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(helm): bump all dependencies"
-pipelineid: helm/autodiscovery
+#pipelineid: helm/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/helmfile/Policy.yaml
+++ b/updatecli/policies/autodiscovery/helmfile/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helmfile/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helmfile/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/helmfile/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/helmfile/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/helmfile/values.yaml
+++ b/updatecli/policies/autodiscovery/helmfile/values.yaml
@@ -1,5 +1,5 @@
 name : "deps(helmfile): bump all dependencies"
-pipelineid: helmfile/autodiscovery
+#pipelineid: helmfile/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/ko/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/ko/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+ 
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/ko/Policy.yaml
+++ b/updatecli/policies/autodiscovery/ko/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/ko/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/ko/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/ko/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/ko/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/ko/values.yaml
+++ b/updatecli/policies/autodiscovery/ko/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(ko): bump all dependencies"
-pipelineid: ko/autodiscovery
+#pipelineid: ko/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/kubernetes/Policy.yaml
+++ b/updatecli/policies/autodiscovery/kubernetes/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/kubernetes/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/kubernetes/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/kubernetes/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/kubernetes/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/kubernetes/values.yaml
+++ b/updatecli/policies/autodiscovery/kubernetes/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(kubernetes): bump all dependencies"
-pipelineid: kubernetes/autodiscovery
+#pipelineid: kubernetes/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/maven/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/maven/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/maven/Policy.yaml
+++ b/updatecli/policies/autodiscovery/maven/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/maven/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/maven/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/maven/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/maven/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/maven/values.yaml
+++ b/updatecli/policies/autodiscovery/maven/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(maven): bump all dependencies"
-pipelineid: maven/autodiscovery
+#pipelineid: maven/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/npm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.8.0
+
+* By default, undefined pipelineid
+
 ## 0.7.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/npm/Policy.yaml
+++ b/updatecli/policies/autodiscovery/npm/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/npm/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/npm/"
-version: 0.7.0
+version: 0.8.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/npm/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/npm/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/npm/values.yaml
+++ b/updatecli/policies/autodiscovery/npm/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(npm): bump all dependencies"
-pipelineid: npm/autodiscovery
+#pipelineid: npm/autodiscovery
 automerge: false
 
 autodiscovery:

--- a/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/rancher/fleet/Policy.yaml
+++ b/updatecli/policies/autodiscovery/rancher/fleet/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/rancher/fleet/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/rancher/fleet/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/rancher/fleet/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/rancher/fleet/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/rancher/fleet/values.yaml
+++ b/updatecli/policies/autodiscovery/rancher/fleet/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(rancher/fleet): bump dependencies"
-pipelineid: rancher/fleet/autodiscovery
+#pipelineid: rancher/fleet/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* By default, undefined pipelineid
+
 ## 0.2.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/terraform/Policy.yaml
+++ b/updatecli/policies/autodiscovery/terraform/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terraform/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terraform/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/terraform/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/terraform/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/terraform/values.yaml
+++ b/updatecli/policies/autodiscovery/terraform/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(terraform): bump all dependencies"
-pipelineid: terraform/autodiscovery
+#pipelineid: terraform/autodiscovery
 automerge: false
 
 scm:

--- a/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* By default, undefined pipelineid
+
 ## 0.3.0
 
 * Allow to override pipeline name

--- a/updatecli/policies/autodiscovery/updatecli/Policy.yaml
+++ b/updatecli/policies/autodiscovery/updatecli/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/updatecli/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/updatecli/"
-version: 0.3.0
+version: 0.4.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/updatecli/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/updatecli/updatecli.d/default.tpl
@@ -6,7 +6,9 @@
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 
 name: '{{ .name }}'
-pipelineid: {{ .pipelineid }}
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
 
 autodiscovery:
   groupby: {{ .groupby }}

--- a/updatecli/policies/autodiscovery/updatecli/values.yaml
+++ b/updatecli/policies/autodiscovery/updatecli/values.yaml
@@ -1,5 +1,5 @@
 name: "deps(updatecli): bump all policies"
-pipelineid: updatecli/autodiscovery
+#pipelineid: updatecli/autodiscovery
 automerge: false
 
 scm:


### PR DESCRIPTION
By default undefine pipelineid for autodiscovery policies. The goal is to avoid using the same pipelineid when using different pipeline name


## Description

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
