### PR TITLE
feat: support set commit using GitHub API using

### DIFF
--- a/updatecli/policies/autodiscovery/all/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/all/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.6.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.5.0
 

--- a/updatecli/policies/autodiscovery/all/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/all/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 
 
+## 0.6.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.5.0
 
 * By default undefined pipelineid

--- a/updatecli/policies/autodiscovery/all/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/all/updatecli.d/default.tpl
@@ -53,6 +53,9 @@ scms:
       # {{ $GitHubUsername := env "GITHUB_ACTOR"}}}
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 {{ end }}
 
 {{ if or (.action.enabled) (env "GITHUB_REPOSITORY") }}

--- a/updatecli/policies/autodiscovery/all/values.yaml
+++ b/updatecli/policies/autodiscovery/all/values.yaml
@@ -55,3 +55,4 @@ scm:
   # username: ""
   # Specify your GitHub Branch name to target
   # branch: "main"
+  # commitusingapi: false

--- a/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * By default undefined pipelineid

--- a/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/autodiscovery/cargo/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/cargo/testdata/values.yaml
@@ -7,4 +7,5 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/autodiscovery/cargo/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/cargo/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/cargo/values.yaml
+++ b/updatecli/policies/autodiscovery/cargo/values.yaml
@@ -12,6 +12,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/autodiscovery/dockercompose/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/dockercompose/testdata/values.yaml
@@ -7,4 +7,5 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/autodiscovery/dockercompose/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/dockercompose/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/dockercompose/values.yaml
+++ b/updatecli/policies/autodiscovery/dockercompose/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/autodiscovery/dockerfile/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/dockerfile/testdata/values.yaml
@@ -7,6 +7,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 
 spec:
   ignore:

--- a/updatecli/policies/autodiscovery/dockerfile/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/dockerfile/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/dockerfile/values.yaml
+++ b/updatecli/policies/autodiscovery/dockerfile/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/flux/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/flux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/flux/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/flux/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/autodiscovery/flux/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/flux/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/flux/values.yaml
+++ b/updatecli/policies/autodiscovery/flux/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/golang/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/golang/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.8.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.7.0
 

--- a/updatecli/policies/autodiscovery/golang/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/golang/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.7.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/golang/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/golang/testdata/values.yaml
@@ -6,4 +6,5 @@ scm:
   repository: udash
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/autodiscovery/golang/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/golang/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/helm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 # 0.3.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/helm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helm/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 # 0.3.0
 

--- a/updatecli/policies/autodiscovery/helm/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/helm/testdata/values.yaml
@@ -7,4 +7,5 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/autodiscovery/helm/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/helm/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/helm/values.yaml
+++ b/updatecli/policies/autodiscovery/helm/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/autodiscovery/helmfile/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/helmfile/testdata/values.yaml
@@ -7,4 +7,5 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/autodiscovery/helmfile/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/helmfile/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/helmfile/values.yaml
+++ b/updatecli/policies/autodiscovery/helmfile/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/ko/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/ko/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
  
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/ko/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/ko/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
  

--- a/updatecli/policies/autodiscovery/ko/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/ko/testdata/values.yaml
@@ -7,4 +7,5 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/autodiscovery/ko/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/ko/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/ko/values.yaml
+++ b/updatecli/policies/autodiscovery/ko/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/autodiscovery/kubernetes/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/kubernetes/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/kubernetes/values.yaml
+++ b/updatecli/policies/autodiscovery/kubernetes/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/maven/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/maven/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/maven/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/maven/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/autodiscovery/maven/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/maven/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/maven/values.yaml
+++ b/updatecli/policies/autodiscovery/maven/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/npm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/npm/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.9.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.8.0
 

--- a/updatecli/policies/autodiscovery/npm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.9.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.8.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/npm/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/npm/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/autodiscovery/rancher/fleet/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/rancher/fleet/testdata/values.yaml
@@ -6,4 +6,5 @@ scm:
   repository: fleet-lab
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/autodiscovery/rancher/fleet/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/rancher/fleet/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/rancher/fleet/values.yaml
+++ b/updatecli/policies/autodiscovery/rancher/fleet/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/autodiscovery/terraform/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/terraform/testdata/values.yaml
@@ -7,4 +7,5 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/autodiscovery/terraform/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/terraform/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/terraform/values.yaml
+++ b/updatecli/policies/autodiscovery/terraform/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.4.0
 

--- a/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.4.0
 
 * By default, undefined pipelineid

--- a/updatecli/policies/autodiscovery/updatecli/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/updatecli/updatecli.d/default.tpl
@@ -34,6 +34,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/autodiscovery/updatecli/values.yaml
+++ b/updatecli/policies/autodiscovery/updatecli/values.yaml
@@ -11,6 +11,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/golang/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/golang/autodiscovery/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.6.0
 

--- a/updatecli/policies/golang/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/golang/autodiscovery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.6.0
 
 * Allow to set pipeline name using `name`

--- a/updatecli/policies/golang/autodiscovery/testdata/values.yaml
+++ b/updatecli/policies/golang/autodiscovery/testdata/values.yaml
@@ -6,4 +6,5 @@ scm:
   repository: udash
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
@@ -32,6 +32,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/golang/version/CHANGELOG.md
+++ b/updatecli/policies/golang/version/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.1.0
 

--- a/updatecli/policies/golang/version/CHANGELOG.md
+++ b/updatecli/policies/golang/version/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.1.0
 
 * Init policy

--- a/updatecli/policies/golang/version/testdata/values.yaml
+++ b/updatecli/policies/golang/version/testdata/values.yaml
@@ -6,4 +6,5 @@ scm:
   repository: udash
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/golang/version/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/version/updatecli.d/default.tpl
@@ -49,6 +49,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
+++ b/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.0
+
+  * Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.1.0
 
   * Initial release

--- a/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
+++ b/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0
 
-  * Allow to set commit using GitHub API using `scm.commitusingapi`
+  * Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.1.0
 

--- a/updatecli/policies/golangci-lint/githubaction/testdata/values.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/testdata/values.yaml
@@ -6,4 +6,5 @@ scm:
   repository: updatecli
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/golangci-lint/githubaction/updatecli.d/default.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/updatecli.d/default.yaml
@@ -34,6 +34,9 @@ scms:
             token: '{{ default $GitHubPAT .scm.token }}'
             username: '{{ default $GitHubUsername .scm.username }}'
             branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 # {{ end }}
 
 sources:

--- a/updatecli/policies/hugo/githubaction/CHANGELOG.md
+++ b/updatecli/policies/hugo/githubaction/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.4.0
 

--- a/updatecli/policies/hugo/githubaction/CHANGELOG.md
+++ b/updatecli/policies/hugo/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.4.0
 
 * Swap default order for scm configuration to use environment variable if nothing else is defined

--- a/updatecli/policies/hugo/githubaction/updatecli.d/manifest.yaml
+++ b/updatecli/policies/hugo/githubaction/updatecli.d/manifest.yaml
@@ -34,6 +34,9 @@ scms:
             token: '{{ default $GitHubPAT .scm.token }}'
             username: '{{ default $GitHubUsername .scm.username }}'
             branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 # {{ end }}
 
 sources:

--- a/updatecli/policies/hugo/netlify/CHANGELOG.md
+++ b/updatecli/policies/hugo/netlify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * Swap default order for scm configuration to use environment variable if nothing else is defined

--- a/updatecli/policies/hugo/netlify/CHANGELOG.md
+++ b/updatecli/policies/hugo/netlify/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/hugo/netlify/updatecli.d/manifest.yaml
+++ b/updatecli/policies/hugo/netlify/updatecli.d/manifest.yaml
@@ -34,6 +34,9 @@ scms:
             token: '{{ default $GitHubPAT .scm.token }}'
             username: '{{ default $GitHubUsername  .scm.username }}'
             branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 # {{ end }}
 
 sources:

--- a/updatecli/policies/nodejs/githubaction/CHANGELOG.md
+++ b/updatecli/policies/nodejs/githubaction/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.4.0
 

--- a/updatecli/policies/nodejs/githubaction/CHANGELOG.md
+++ b/updatecli/policies/nodejs/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.4.0
 
 * Swap default order for scm configuration to use environment variable if nothing else is defined

--- a/updatecli/policies/nodejs/githubaction/updatecli.d/manifest.yaml
+++ b/updatecli/policies/nodejs/githubaction/updatecli.d/manifest.yaml
@@ -34,6 +34,9 @@ scms:
             token: '{{ default $GitHubPAT .scm.token }}'
             username: '{{ default $GitHubUsername .scm.username }}'
             branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 # {{ end }}
 
 sources:

--- a/updatecli/policies/nodejs/netlify/CHANGELOG.md
+++ b/updatecli/policies/nodejs/netlify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.3.0
 
 * Swap default order for scm configuration to use environment variable if nothing else is defined

--- a/updatecli/policies/nodejs/netlify/CHANGELOG.md
+++ b/updatecli/policies/nodejs/netlify/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.3.0
 

--- a/updatecli/policies/nodejs/netlify/updatecli.d/manifest.yaml
+++ b/updatecli/policies/nodejs/netlify/updatecli.d/manifest.yaml
@@ -34,6 +34,9 @@ scms:
             token: '{{ default $GitHubPAT .scm.token }}'
             username: '{{ default $GitHubUsername .scm.username }}'
             branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 # {{ end }}
 
 sources:

--- a/updatecli/policies/npm/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/npm/autodiscovery/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.6.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.6.0
 

--- a/updatecli/policies/npm/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/npm/autodiscovery/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.6.0
+## 0.7.0
 
 * Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 

--- a/updatecli/policies/npm/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/npm/autodiscovery/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.6.0
 
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
+## 0.6.0
+
 * Rename `npm.spec` to `spec`
 * By default don't set groupby
 * Cleaning test setting

--- a/updatecli/policies/npm/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/npm/autodiscovery/updatecli.d/default.tpl
@@ -32,6 +32,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/npm/netlify/CHANGELOG.md
+++ b/updatecli/policies/npm/netlify/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.4.0
 

--- a/updatecli/policies/npm/netlify/CHANGELOG.md
+++ b/updatecli/policies/npm/netlify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.4.0
 
 * Cleaning testdata

--- a/updatecli/policies/npm/netlify/updatecli.d/manifest.yaml
+++ b/updatecli/policies/npm/netlify/updatecli.d/manifest.yaml
@@ -33,6 +33,9 @@ scms:
             token: '{{ default $GitHubPAT .scm.token }}'
             username: '{{ default $GitHubUsername .scm.username }}'
             branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 # {{ end }}
 
 sources:

--- a/updatecli/policies/pulumi/CHANGELOG.md
+++ b/updatecli/policies/pulumi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.0
+
+  * Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.1.0
 
   * Initial release

--- a/updatecli/policies/pulumi/CHANGELOG.md
+++ b/updatecli/policies/pulumi/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0
 
-  * Allow to set commit using GitHub API using `scm.commitusingapi`
+  * Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.1.0
 

--- a/updatecli/policies/pulumi/testdata/values.yaml
+++ b/updatecli/policies/pulumi/testdata/values.yaml
@@ -3,6 +3,7 @@ scm:
     owner: pulumiverse
     repository: pulumi-talos
     branch: main
+  commitusingapi: true
     user: updatecli
     email: 
     #username: 

--- a/updatecli/policies/pulumi/updatecli.d/pulumi-pkg.yaml
+++ b/updatecli/policies/pulumi/updatecli.d/pulumi-pkg.yaml
@@ -13,6 +13,9 @@ scms:
       email: "{{ .scm.default.email }}"
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 ## actions defines what to do when a target with the same scmid is modified.
 actions:

--- a/updatecli/policies/pulumi/updatecli.d/pulumi-sdk.yaml
+++ b/updatecli/policies/pulumi/updatecli.d/pulumi-sdk.yaml
@@ -13,6 +13,9 @@ scms:
       email: "{{ .scm.default.email }}"
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 ## actions defines what to do when a target with the same scmid is modified.
 actions:

--- a/updatecli/policies/pulumi/values.yaml
+++ b/updatecli/policies/pulumi/values.yaml
@@ -8,3 +8,4 @@
 #     repository: github_repository
 #     username: "updatecli-bot"
 #     branch: main
+  # commitusingapi: false

--- a/updatecli/policies/rancher/fleet/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/rancher/fleet/autodiscovery/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.1.0
 

--- a/updatecli/policies/rancher/fleet/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/rancher/fleet/autodiscovery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.1.0
 
 * Init policy

--- a/updatecli/policies/rancher/fleet/autodiscovery/testdata/values.yaml
+++ b/updatecli/policies/rancher/fleet/autodiscovery/testdata/values.yaml
@@ -9,4 +9,5 @@ scm:
   repository: fleet-lab
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 

--- a/updatecli/policies/rancher/fleet/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/rancher/fleet/autodiscovery/updatecli.d/default.tpl
@@ -31,6 +31,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/releasepost/releasepost/CHANGELOG.md
+++ b/updatecli/policies/releasepost/releasepost/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.1.0
 

--- a/updatecli/policies/releasepost/releasepost/CHANGELOG.md
+++ b/updatecli/policies/releasepost/releasepost/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.1.0
 
 * Init policy

--- a/updatecli/policies/releasepost/releasepost/testdata/values.yaml
+++ b/updatecli/policies/releasepost/releasepost/testdata/values.yaml
@@ -7,5 +7,6 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  commitusingapi: true
 
 configpath: config.example.yaml

--- a/updatecli/policies/releasepost/releasepost/updatecli.d/default.tpl
+++ b/updatecli/policies/releasepost/releasepost/updatecli.d/default.tpl
@@ -41,6 +41,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/releasepost/releasepost/values.yaml
+++ b/updatecli/policies/releasepost/releasepost/values.yaml
@@ -14,4 +14,5 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 

--- a/updatecli/policies/updatecli/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/updatecli/autodiscovery/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.3.0
 
-* Allow to set commit using GitHub API using `scm.commitusingapi`
+* Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`
 
 ## 0.2.0
 

--- a/updatecli/policies/updatecli/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/updatecli/autodiscovery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* Allow to set commit using GitHub API using `scm.commitusingapi`
+
 ## 0.2.0
 
 * Set default groupby to "all"

--- a/updatecli/policies/updatecli/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/updatecli/autodiscovery/updatecli.d/default.tpl
@@ -32,6 +32,9 @@ scms:
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 
 actions:
   default:

--- a/updatecli/policies/updatecli/autodiscovery/values.yaml
+++ b/updatecli/policies/updatecli/autodiscovery/values.yaml
@@ -10,6 +10,7 @@ scm:
   #token: "xxx"
   username: "updatecli-bot"
   branch: main
+  # commitusingapi: false
 
 # spec:
 groupby: all

--- a/updatecli/policies/updatecli/githubaction/updatecli.d/action-version.yaml
+++ b/updatecli/policies/updatecli/githubaction/updatecli.d/action-version.yaml
@@ -34,6 +34,9 @@ scms:
             token: '{{ default $GitHubPAT .scm.token }}'
             username: '{{ default $GitHubUsername .scm.username }}'
             branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 # {{ end }}
 
 sources:

--- a/updatecli/policies/updatecli/githubaction/updatecli.d/action.yaml
+++ b/updatecli/policies/updatecli/githubaction/updatecli.d/action.yaml
@@ -34,6 +34,9 @@ scms:
             token: '{{ default $GitHubPAT .scm.token }}'
             username: '{{ default $GitHubUsername .scm.username }}'
             branch: '{{ .scm.branch }}'
+#{{ if .scm.commitusingapi }}
+      commitusingapi: {{ .scm.commitusingapi }}
+# {{ end }}
 # {{ end }}
 
 sources:


### PR DESCRIPTION
## Description

Enable `commitusingapi` which defines if Updatecli should use GitHub GraphQL API to create the commit. This requires `--experimental`, but I have not found a way to validate if `--experimental` is not configured then don't honour `commitusingapi`.

I added the changelog entries but I didn't bump the versions.

## Test

I added `commitusingapi: true` in the test-data.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
