### PR TITLE
feat: opt-out scm.email

### DIFF
--- a/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Allow to opt out `scm.email`.
+
 ## 0.5.0
 
 * Allow to set commit with GitHub GraphQL API using `scm.commitusingapi`

--- a/updatecli/policies/autodiscovery/updatecli/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/updatecli/updatecli.d/default.tpl
@@ -28,7 +28,9 @@ scms:
     spec:
       # Priority set to the environment variable
       user: '{{ default $GitHubUser .scm.user }}'
+#{{ if .scm.email }}
       email: '{{ .scm.email }}'
+# {{ end }}
       owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
       repository: '{{ default $GitHubRepositoryList._1 .scm.repository }}'
       token: '{{ default $GitHubPAT .scm.token }}'


### PR DESCRIPTION
<!-- Provide a link to the issue you are solving in this pull request -->
Fix #XXX
<!-- Provide a link to the documentation related to this this pull request -->
[Documentation](https://)

## Description

This is handy when using `scm.commitusingapi: true`, `email` and `user` are not required IIRC.

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
