### PR TITLE
feat(labels): customise the GitHub labels

### DIFF
--- a/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/cargo/Policy.yaml
+++ b/updatecli/policies/autodiscovery/cargo/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/cargo/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/cargo/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/cargo/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/cargo/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/cargo/values.yaml
+++ b/updatecli/policies/autodiscovery/cargo/values.yaml
@@ -2,6 +2,8 @@ name: "deps(cargo): bump all policies"
 
 # pipelineid: cargo/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/dockercompose/Policy.yaml
+++ b/updatecli/policies/autodiscovery/dockercompose/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockercompose/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockercompose/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/dockercompose/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/dockercompose/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/dockercompose/values.yaml
+++ b/updatecli/policies/autodiscovery/dockercompose/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(dockercompose): bump dependencies"
 # pipelineid: dockercompose/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/dockerfile/Policy.yaml
+++ b/updatecli/policies/autodiscovery/dockerfile/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockerfile/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockerfile/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/dockerfile/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/dockerfile/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/dockerfile/values.yaml
+++ b/updatecli/policies/autodiscovery/dockerfile/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(dockerfile): bump all dependencies"
 #pipelineid: dockerfile/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/flux/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/flux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/flux/Policy.yaml
+++ b/updatecli/policies/autodiscovery/flux/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/flux/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/flux/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/flux/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/flux/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/flux/values.yaml
+++ b/updatecli/policies/autodiscovery/flux/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(flux): bump all dependencies"
 #pipelineid: flux/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/golang/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/golang/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.9.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/golang/Policy.yaml
+++ b/updatecli/policies/autodiscovery/golang/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/golang/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/golang/"
-version: 0.9.0
+version: 0.10.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/golang/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/golang/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/golang/values.yaml
+++ b/updatecli/policies/autodiscovery/golang/values.yaml
@@ -1,6 +1,8 @@
 name: 'deps(golang): Bump all dependencies'
 #pipelineid: golang/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/helm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/helm/Policy.yaml
+++ b/updatecli/policies/autodiscovery/helm/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helm/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helm/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/helm/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/helm/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/helm/values.yaml
+++ b/updatecli/policies/autodiscovery/helm/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(helm): bump all dependencies"
 #pipelineid: helm/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/helmfile/Policy.yaml
+++ b/updatecli/policies/autodiscovery/helmfile/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helmfile/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helmfile/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/helmfile/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/helmfile/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/helmfile/values.yaml
+++ b/updatecli/policies/autodiscovery/helmfile/values.yaml
@@ -1,6 +1,8 @@
 name : "deps(helmfile): bump all dependencies"
 #pipelineid: helmfile/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/ko/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/ko/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/ko/Policy.yaml
+++ b/updatecli/policies/autodiscovery/ko/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/ko/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/ko/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/ko/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/ko/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/ko/values.yaml
+++ b/updatecli/policies/autodiscovery/ko/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(ko): bump all dependencies"
 #pipelineid: ko/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/kubernetes/Policy.yaml
+++ b/updatecli/policies/autodiscovery/kubernetes/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/kubernetes/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/kubernetes/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/kubernetes/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/kubernetes/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/kubernetes/values.yaml
+++ b/updatecli/policies/autodiscovery/kubernetes/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(kubernetes): bump all dependencies"
 #pipelineid: kubernetes/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/maven/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/maven/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/maven/Policy.yaml
+++ b/updatecli/policies/autodiscovery/maven/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/maven/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/maven/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/maven/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/maven/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/maven/values.yaml
+++ b/updatecli/policies/autodiscovery/maven/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(maven): bump all dependencies"
 #pipelineid: maven/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/npm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/npm/CHANGELOG.md
@@ -1,4 +1,8 @@
-# CHANGELOG
+# Changelog
+
+## 0.11.0
+
+* Configure Pull Request GitHub labels using `labels`.
 
 ## 0.10.0
 

--- a/updatecli/policies/autodiscovery/npm/Policy.yaml
+++ b/updatecli/policies/autodiscovery/npm/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/npm/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/npm/"
-version: 0.10.0
+version: 0.11.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/npm/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/npm/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/npm/values.yaml
+++ b/updatecli/policies/autodiscovery/npm/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(npm): bump all dependencies"
 #pipelineid: npm/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 autodiscovery:
   groupby: all

--- a/updatecli/policies/autodiscovery/prow/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/prow/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.2.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/prow/Policy.yaml
+++ b/updatecli/policies/autodiscovery/prow/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/prow/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/prow/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/prow/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/prow/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/prow/values.yaml
+++ b/updatecli/policies/autodiscovery/prow/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(prow): bump all dependencies"
 #pipelineid: prow/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/rancher/fleet/Policy.yaml
+++ b/updatecli/policies/autodiscovery/rancher/fleet/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/rancher/fleet/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/rancher/fleet/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/rancher/fleet/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/rancher/fleet/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/rancher/fleet/values.yaml
+++ b/updatecli/policies/autodiscovery/rancher/fleet/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(rancher/fleet): bump dependencies"
 #pipelineid: rancher/fleet/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/terraform/Policy.yaml
+++ b/updatecli/policies/autodiscovery/terraform/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terraform/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terraform/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/terraform/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/terraform/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/terraform/values.yaml
+++ b/updatecli/policies/autodiscovery/terraform/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(terraform): bump all dependencies"
 #pipelineid: terraform/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/terragrunt/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/terragrunt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.2.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/terragrunt/Policy.yaml
+++ b/updatecli/policies/autodiscovery/terragrunt/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terragrunt/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terragrunt/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/terragrunt/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/terragrunt/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/terragrunt/values.yaml
+++ b/updatecli/policies/autodiscovery/terragrunt/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(terragrunt): bump all policies"
 #pipelineid: terragrunt/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.7.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/autodiscovery/updatecli/Policy.yaml
+++ b/updatecli/policies/autodiscovery/updatecli/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/updatecli/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/updatecli/"
-version: 0.7.0
+version: 0.8.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/updatecli/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/updatecli/updatecli.d/default.tpl
@@ -46,7 +46,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/autodiscovery/updatecli/values.yaml
+++ b/updatecli/policies/autodiscovery/updatecli/values.yaml
@@ -1,6 +1,8 @@
 name: "deps(updatecli): bump all policies"
 #pipelineid: updatecli/autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/golang/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/golang/autodiscovery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.8.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/golang/autodiscovery/Policy.yaml
+++ b/updatecli/policies/golang/autodiscovery/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/autodiscovery/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/autodiscovery/"
-version: 0.8.0
+version: 0.9.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
@@ -44,7 +44,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/golang/autodiscovery/values.yaml
+++ b/updatecli/policies/golang/autodiscovery/values.yaml
@@ -1,6 +1,8 @@
 name: 'deps(golang): Bump all dependencies'
 pipelineid: golang/autodiscovery/all
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/golang/version/CHANGELOG.md
+++ b/updatecli/policies/golang/version/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.3.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/golang/version/Policy.yaml
+++ b/updatecli/policies/golang/version/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/version/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/version/"
-version: 0.3.0
+version: 0.4.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/golang/version/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/version/updatecli.d/default.tpl
@@ -61,8 +61,12 @@ actions:
     kind: "github/pullrequest"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
     scmid: "default"
 {{ end }}
 

--- a/updatecli/policies/golang/version/values.yaml
+++ b/updatecli/policies/golang/version/values.yaml
@@ -1,6 +1,8 @@
 name: 'deps: Bump Golang version'
 pipelineid: golang/version
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
+++ b/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
@@ -1,4 +1,8 @@
-# CHANGELOG
+# Changelog
+
+## 0.4.0
+
+* Configure Pull Request GitHub labels using `labels`.
 
 ## 0.3.0
 

--- a/updatecli/policies/golangci-lint/githubaction/Policy.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golangci-lint/githubaction/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golangci-lint/githubaction/"
-version: 0.3.0
+version: 0.4.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/golangci-lint/githubaction/updatecli.d/default.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/updatecli.d/default.yaml
@@ -16,9 +16,12 @@ actions:
         kind: "github/pullrequest"
         spec:
             automerge: {{ .automerge }}
+# {{ if .labels }}
             labels:
-                - "chore"
-                - "dependencies"
+# {{ range .labels }}
+                - {{ . }}
+# {{ end }}
+# {{ end }}
             mergemethod: "squash"
         scmid: "default"
 

--- a/updatecli/policies/golangci-lint/githubaction/values.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/values.yaml
@@ -1,5 +1,8 @@
 pipelineid: golangci-lint
 automerge: false
+labels:
+  - chore
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/hugo/githubaction/CHANGELOG.md
+++ b/updatecli/policies/hugo/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.6.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/hugo/githubaction/Policy.yaml
+++ b/updatecli/policies/hugo/githubaction/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/githubaction/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/githubaction/"
-version: 0.6.0
+version: 0.7.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/hugo/githubaction/updatecli.d/manifest.yaml
+++ b/updatecli/policies/hugo/githubaction/updatecli.d/manifest.yaml
@@ -16,9 +16,12 @@ actions:
         kind: "github/pullrequest"
         spec:
             automerge: {{ .automerge }}
+# {{ if .labels }}
             labels:
-                - "chore"
-                - "dependencies"
+# {{ range .labels }}
+                - {{ . }}
+# {{ end }}
+# {{ end }}
             mergemethod: "squash"
         scmid: "default"
 

--- a/updatecli/policies/hugo/githubaction/values.yaml
+++ b/updatecli/policies/hugo/githubaction/values.yaml
@@ -1,5 +1,8 @@
 pipelineid: hugo
 automerge: false
+labels:
+  - chore
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/hugo/netlify/CHANGELOG.md
+++ b/updatecli/policies/hugo/netlify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/hugo/netlify/Policy.yaml
+++ b/updatecli/policies/hugo/netlify/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/netlify/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/netlify/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/hugo/netlify/updatecli.d/manifest.yaml
+++ b/updatecli/policies/hugo/netlify/updatecli.d/manifest.yaml
@@ -16,9 +16,12 @@ actions:
         kind: "github/pullrequest"
         spec:
             automerge: {{ .automerge }}
+# {{ if .labels }}
             labels:
-                - "chore"
-                - "dependencies"
+# {{ range .labels }}
+                - {{ . }}
+# {{ end }}
+# {{ end }}
             mergemethod: "squash"
         scmid: "default"
 

--- a/updatecli/policies/hugo/netlify/values.yaml
+++ b/updatecli/policies/hugo/netlify/values.yaml
@@ -1,5 +1,8 @@
 pipelineid: hugo
 automerge: false
+labels:
+  - chore
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/nodejs/githubaction/CHANGELOG.md
+++ b/updatecli/policies/nodejs/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.6.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/nodejs/githubaction/Policy.yaml
+++ b/updatecli/policies/nodejs/githubaction/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/githubaction/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/githubaction/"
-version: 0.6.0
+version: 0.7.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/nodejs/githubaction/updatecli.d/manifest.yaml
+++ b/updatecli/policies/nodejs/githubaction/updatecli.d/manifest.yaml
@@ -16,9 +16,12 @@ actions:
         kind: "github/pullrequest"
         spec:
             automerge: {{ .automerge }}
+# {{ if .labels }}
             labels:
-                - "chore"
-                - "dependencies"
+# {{ range .labels }}
+                - {{ . }}
+# {{ end }}
+# {{ end }}
             mergemethod: "squash"
         scmid: "default"
 

--- a/updatecli/policies/nodejs/githubaction/values.yaml
+++ b/updatecli/policies/nodejs/githubaction/values.yaml
@@ -1,5 +1,8 @@
 pipelineid: nodejs
 automerge: false
+labels:
+  - chore
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/nodejs/netlify/CHANGELOG.md
+++ b/updatecli/policies/nodejs/netlify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.5.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/nodejs/netlify/Policy.yaml
+++ b/updatecli/policies/nodejs/netlify/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/netlify/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/netlify/"
-version: 0.5.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/nodejs/netlify/updatecli.d/manifest.yaml
+++ b/updatecli/policies/nodejs/netlify/updatecli.d/manifest.yaml
@@ -16,9 +16,12 @@ actions:
         kind: "github/pullrequest"
         spec:
             automerge: {{ .automerge }}
+# {{ if .labels }}
             labels:
-                - "chore"
-                - "dependencies"
+# {{ range .labels }}
+                - {{ . }}
+# {{ end }}
+# {{ end }}
             mergemethod: "squash"
         scmid: "default"
 

--- a/updatecli/policies/nodejs/netlify/values.yaml
+++ b/updatecli/policies/nodejs/netlify/values.yaml
@@ -1,5 +1,8 @@
 pipelineid: nodejs
 automerge: false
+labels:
+  - chore
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/npm/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/npm/autodiscovery/CHANGELOG.md
@@ -1,4 +1,8 @@
-# CHANGELOG
+# Changelog
+
+## 0.9.0
+
+* Configure Pull Request GitHub labels using `labels`.
 
 ## 0.8.0
 

--- a/updatecli/policies/npm/autodiscovery/Policy.yaml
+++ b/updatecli/policies/npm/autodiscovery/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/autodiscovery/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/autodiscovery/"
-version: 0.8.0
+version: 0.9.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/npm/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/npm/autodiscovery/updatecli.d/default.tpl
@@ -44,7 +44,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/npm/autodiscovery/values.yaml
+++ b/updatecli/policies/npm/autodiscovery/values.yaml
@@ -1,5 +1,7 @@
 pipelineid: npm_autodiscovery
 automerge: false
+labels:
+  - dependencies
 
 autodiscovery:
   groupby: all

--- a/updatecli/policies/npm/netlify/CHANGELOG.md
+++ b/updatecli/policies/npm/netlify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.6.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/npm/netlify/Policy.yaml
+++ b/updatecli/policies/npm/netlify/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/netlify/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/netlify/"
-version: 0.6.0
+version: 0.7.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/npm/netlify/updatecli.d/manifest.yaml
+++ b/updatecli/policies/npm/netlify/updatecli.d/manifest.yaml
@@ -15,9 +15,12 @@ actions:
         kind: "github/pullrequest"
         spec:
             automerge: {{ .automerge }}
+# {{ if .labels }}
             labels:
-                - "chore"
-                - "dependencies"
+# {{ range .labels }}
+                - {{ . }}
+# {{ end }}
+# {{ end }}
             mergemethod: "squash"
         scmid: "default"
 

--- a/updatecli/policies/npm/netlify/values.yaml
+++ b/updatecli/policies/npm/netlify/values.yaml
@@ -1,5 +1,8 @@
 pipelineid: npm
 automerge: false
+labels:
+  - "chore"
+  - "dependencies"
 
 scm:
   enabled: false

--- a/updatecli/policies/pulumi/CHANGELOG.md
+++ b/updatecli/policies/pulumi/CHANGELOG.md
@@ -1,4 +1,8 @@
-# CHANGELOG
+# Changelog
+
+## 0.4.0
+
+* Configure Pull Request GitHub labels using `labels`.
 
 ## 0.3.0
 

--- a/updatecli/policies/pulumi/Policy.yaml
+++ b/updatecli/policies/pulumi/Policy.yaml
@@ -15,7 +15,7 @@ documentation: "https://github.com/updatecli/policies/tree/main/updatecli/polici
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/pulumi/"
 
 # Version is the policy version. 
-version: 0.3.0
+version: 0.4.0
 
 ## Vendor is the policy vendor
 vendor: Updatecli Project

--- a/updatecli/policies/pulumi/updatecli.d/pulumi-pkg.yaml
+++ b/updatecli/policies/pulumi/updatecli.d/pulumi-pkg.yaml
@@ -24,8 +24,12 @@ actions:
     scmid: "default"
     spec:
       automerge: false
+# {{ if .labels }}
       labels:
-        - "dependencies"
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 
 ## sources defines where to find the information.
 sources:

--- a/updatecli/policies/pulumi/updatecli.d/pulumi-sdk.yaml
+++ b/updatecli/policies/pulumi/updatecli.d/pulumi-sdk.yaml
@@ -24,8 +24,12 @@ actions:
     scmid: "default"
     spec:
       automerge: false
+# {{ if .labels }}
       labels:
-        - "dependencies"
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 
 ## sources defines where to find the information.
 sources:

--- a/updatecli/policies/pulumi/values.yaml
+++ b/updatecli/policies/pulumi/values.yaml
@@ -9,3 +9,6 @@
 #     username: "updatecli-bot"
 #     branch: main
   # commitusingapi: false
+
+labels:
+  - dependencies

--- a/updatecli/policies/rancher/fleet/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/rancher/fleet/autodiscovery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.3.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/rancher/fleet/autodiscovery/Policy.yaml
+++ b/updatecli/policies/rancher/fleet/autodiscovery/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/rancher/fleet/autodiscovery/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/rancher/fleet/autodiscovery/"
-version: 0.3.0
+version: 0.4.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/rancher/fleet/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/rancher/fleet/autodiscovery/updatecli.d/default.tpl
@@ -43,7 +43,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/rancher/fleet/autodiscovery/values.yaml
+++ b/updatecli/policies/rancher/fleet/autodiscovery/values.yaml
@@ -1,5 +1,7 @@
 pipelineid: rancher_fleet
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/releasepost/releasepost/CHANGELOG.md
+++ b/updatecli/policies/releasepost/releasepost/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.3.0
 
 * Allow to opt out `scm.email`

--- a/updatecli/policies/releasepost/releasepost/Policy.yaml
+++ b/updatecli/policies/releasepost/releasepost/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/releasepost/releasepost/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/releasepost/releasepost/"
-version: 0.3.0
+version: 0.6.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/releasepost/releasepost/README.md
+++ b/updatecli/policies/releasepost/releasepost/README.md
@@ -94,6 +94,8 @@ actions:
         kind: github/pullrequest
         spec:
             automerge: false
+labels:
+  - dependencies
             labels:
                 - documentation
         scmid: default

--- a/updatecli/policies/releasepost/releasepost/updatecli.d/default.tpl
+++ b/updatecli/policies/releasepost/releasepost/updatecli.d/default.tpl
@@ -53,7 +53,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - documentation
+# {{ range .labels }}
+         - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/releasepost/releasepost/values.yaml
+++ b/updatecli/policies/releasepost/releasepost/values.yaml
@@ -1,5 +1,7 @@
 pipelineid: releasepost
 automerge: false
+labels:
+  - documentation
 
 configpath: ".releasepost.yaml"
 

--- a/updatecli/policies/updatecli/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/updatecli/autodiscovery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.4.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/updatecli/autodiscovery/Policy.yaml
+++ b/updatecli/policies/updatecli/autodiscovery/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/autodiscovery/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/autodiscovery/"
-version: 0.4.0
+version: 0.5.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/updatecli/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/updatecli/autodiscovery/updatecli.d/default.tpl
@@ -44,7 +44,11 @@ actions:
     scmid: "default"
     spec:
       automerge: {{ .automerge }}
+# {{ if .labels }}
       labels:
-         - dependencies
+# {{ range .labels }}
+        - {{ . }}
+# {{ end }}
+# {{ end }}
 {{ end }}
 

--- a/updatecli/policies/updatecli/autodiscovery/values.yaml
+++ b/updatecli/policies/updatecli/autodiscovery/values.yaml
@@ -1,5 +1,7 @@
 pipelineid: updatecli_policies
 automerge: false
+labels:
+  - dependencies
 
 scm:
   enabled: false

--- a/updatecli/policies/updatecli/githubaction/CHANGELOG.md
+++ b/updatecli/policies/updatecli/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* Configure Pull Request GitHub labels using `labels`.
+
 ## 0.2.0
 
 * Allow to opt out `scm.email`.

--- a/updatecli/policies/updatecli/githubaction/Policy.yaml
+++ b/updatecli/policies/updatecli/githubaction/Policy.yaml
@@ -4,7 +4,7 @@ authors:
 url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/githubaction/README.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/githubaction/"
-version: 0.2.0
+version: 0.3.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/updatecli/githubaction/updatecli.d/action-version.yaml
+++ b/updatecli/policies/updatecli/githubaction/updatecli.d/action-version.yaml
@@ -16,9 +16,12 @@ actions:
         kind: "github/pullrequest"
         spec:
             automerge: {{ .automerge }}
+# {{ if .labels }}
             labels:
-                - "chore"
-                - "dependencies"
+# {{ range .labels }}
+                - {{ . }}
+# {{ end }}
+# {{ end }}
             mergemethod: "squash"
         scmid: "default"
 

--- a/updatecli/policies/updatecli/githubaction/updatecli.d/action.yaml
+++ b/updatecli/policies/updatecli/githubaction/updatecli.d/action.yaml
@@ -16,9 +16,12 @@ actions:
         kind: "github/pullrequest"
         spec:
             automerge: {{ .automerge }}
+# {{ if .labels }}
             labels:
-                - "chore"
-                - "dependencies"
+# {{ range .labels }}
+                - {{ . }}
+# {{ end }}
+# {{ end }}
             mergemethod: "squash"
         scmid: "default"
 

--- a/updatecli/policies/updatecli/githubaction/values.yaml
+++ b/updatecli/policies/updatecli/githubaction/values.yaml
@@ -1,6 +1,8 @@
 pipelineid: updatecli
 automerge: false
-
+labels:
+  - "chore"
+  - "dependencies"
 scm:
   enabled: false
   # user: updatecli-bot


### PR DESCRIPTION
<!-- Provide a link to the issue you are solving in this pull request -->
Fix https://github.com/updatecli/policies/issues/33
<!-- Provide a link to the documentation related to this this pull request -->
[Documentation](https://)

## Description

Let's use `.labels` and set it with the current default values as agreed.

https://github.com/updatecli/policies/blob/main/updatecli/policies/autodiscovery/all/updatecli.d/default.tpl has not been changed since it uses a different approach.

I didn't bump the versions in their `Policy.yaml`, should I?

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
