### PR TITLE
feat: allow to use the file policy to copy locally

### DIFF
--- a/updatecli/policies/file/CHANGELOG.md
+++ b/updatecli/policies/file/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.0
+
+  * Allow to use the policy without pushing to a git repository
+
 ## 0.1.1
 
   * Allow commit message customization

--- a/updatecli/policies/file/Policy.yaml
+++ b/updatecli/policies/file/Policy.yaml
@@ -16,7 +16,7 @@ documentation: "https://github.com/updatecli/policies/tree/main/updatecli/polici
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/file/"
 
 # Version is the policy version. 
-version: 0.1.1
+version: 0.2.0
 
 # Vendor is the policy vendor
 vendor: Updatecli project

--- a/updatecli/policies/file/testdata/noscm.yaml
+++ b/updatecli/policies/file/testdata/noscm.yaml
@@ -1,9 +1,3 @@
-scm:
-  branch: "main"
-  owner: "updatecli"
-  repository: "udash"
-  username: "updatecli-bot"
-
 src:
   url: "https://github.com/updatecli/updatecli.git"
   branch: "main"

--- a/updatecli/policies/file/updatecli.d/default.yaml
+++ b/updatecli/policies/file/updatecli.d/default.yaml
@@ -2,10 +2,11 @@
 # Helpers
 # {{ $GitHubUser := env ""}}
 # {{ $GitHubRepositoryList := env "GITHUB_REPOSITORY" | split "/"}}
+# {{ $DefaultGitHubOwner := default $GitHubRepositoryList._0 .scm.owner }}
+# {{ $DefaultGitHubRepository := default $GitHubRepositoryList._1 .scm.repository }}
 # {{ $GitHubPAT := env "GITHUB_TOKEN"}}
 # {{ $GitHubUsername := env "GITHUB_ACTOR"}}
 # {{ $DefaultTitle := (print "chore: sync file(s) from " .src.url ) }}
-
 name: '{{ default $DefaultTitle .title }}'
 
 # {{ if .pipelineid }}
@@ -14,42 +15,44 @@ pipelineid: '{{ .pipelineid }}'
 
 # scms defines the source control management system to interact with.
 scms:
+# {{ if and ( ne $DefaultGitHubOwner "") ( ne $DefaultGitHubRepository "") }}
   default:
     kind: "github"
     spec:
       # Priority set to the environment variable
       user: '{{ default $GitHubUser .scm.user}}'
-# {{ if .scm.email }}
+#     {{ if .scm.email }}
       email: '{{ .scm.email }}'
-# {{ end }}
-      owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
-      repository: '{{ default $GitHubRepositoryList._1 .scm.repository}}'
+#     {{ end }}
+      owner: '{{ $DefaultGitHubOwner }}'
+      repository: '{{ $DefaultGitHubRepository }}'
       token: '{{ default $GitHubPAT .scm.token }}'
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
-#{{ if .scm.commitusingapi }}
+#     {{ if .scm.commitusingapi }}
       commitusingapi: {{ .scm.commitusingapi }}
-# {{ end }}
-#{{ if .scm.commitmessage }}
+#     {{ end }}
+#     {{ if .scm.commitmessage }}
       commitmessage:
-#{{ if .scm.commitmessage.type }}
+#           {{ if .scm.commitmessage.type }}
         type: '{{ .scm.commitmessage.type }}'
-# {{ end }}
-#{{ if .scm.commitmessage.title }}
+#           {{ end }}
+#           {{ if .scm.commitmessage.title }}
         title: '{{ .scm.commitmessage.title }}'
-# {{ end }}
-#{{ if .scm.commitmessage.body }}
+#           {{ end }}
+#           {{ if .scm.commitmessage.body }}
         body: '{{ .scm.commitmessage.body }}'
-# {{ end }}
-#{{ if .scm.commitmessage.footers }}
+#           {{ end }}
+#           {{ if .scm.commitmessage.footers }}
         footers: '{{ .scm.commitmessage.footers }}'
-# {{ end }}
-#{{ if .scm.commitmessage.hidecredit }}
+#           {{ end }}
+#           {{ if .scm.commitmessage.hidecredit }}
         hidecredit: {{ .scm.commitmessage.hidecredit }}
-# {{ end }}
-#{{ if .scm.commitmessage.scope }}
+#           {{ end }}
+#           {{ if .scm.commitmessage.scope }}
         scope: '{{ .scm.commitmessage.scope }}'
-# {{ end }}
+#           {{ end }}
+#     {{ end }}
 # {{ end }}
   source:
     kind: git
@@ -74,29 +77,33 @@ targets:
   "{{ $index }}":
     name: 'sync {{ $file.dst }} file'
     kind: 'file'
+#     {{ if and $DefaultGitHubOwner $DefaultGitHubRepository }}
     scmid: 'default'
+#     {{ end }}
     sourceid: '{{ $index }}'
     spec:
       file: '{{ $file.dst }}'
       forcecreate: true
 # {{ end }}
       
+# {{ if and $DefaultGitHubOwner $DefaultGitHubRepository }}
 # actions defines what to do when a target with the same scmid is modified.
 actions:
   default:
     kind: "github/pullrequest"
     spec:
-#    {{ if .pr.title }}
+#     {{ if .pr.title }}
       title: '{{ .pr.title }}'
-#    {{ end }}
-# {{ if .pr.description }}
+#     {{ end }}
+#     {{ if .pr.description }}
       description: '{{ .pr.description }}'
-# {{ end }}
+#     {{ end }}
       automerge: {{ .pr.automerge }}
-# {{ if .pr.labels }}
+#     {{ if .pr.labels }}
       labels:
-# {{ range .pr.labels }}
+#           {{ range .pr.labels }}
         - '{{ . }}'
-# {{ end }}
-# {{ end }}
+#           {{ end }}
+#     {{ end }}
     scmid: "default"
+# {{ end }}

--- a/updatecli/policies/file/values.yaml
+++ b/updatecli/policies/file/values.yaml
@@ -6,8 +6,8 @@
 
 ## files contains the list of files to be copied from the source repository to the target repository.
 #files:
-#  - src: ""
-#    dst: ""
+#  - src: "example.yaml"
+#    dst: "example.yaml"
 
 ## pipelineid is the pipeline id to be used by the policy
 ## It is used to identify the pipeline that is running the policy.
@@ -26,19 +26,19 @@ pr:
 ## src contains the source repository information
 ## It is used to fetch the files to be copied to the target repository
 #src:
-#  url: ""
-#  branch: ""
+#  url: "https://github.com/updatecli/updatecli.git"
+#  branch: "main"
 
 ## scm contains the source control management information
 scm:
   commitusingapi: true
   user: updatecli
-#  email: updatecli-bot@updatecli.io
+  email: updatecli-bot@updatecli.io
 #  owner: updatecli
 #  repository: updatecli
 #  token: "xxx"
-#  username: "updatecli-bot"
-#  branch: main
+  username: "updatecli-bot"
+  branch: main
   commitmessage:
     type:  "chore"
 #    title: "sync file from source repository"


### PR DESCRIPTION
This pull request superseed https://github.com/updatecli/policies/pull/45

The goal is to be able to use the file policy to copy files from a remote repository locally.
The files `testdata/noscm.yaml` and `testdata/values.yaml` are two examples about how to use this policy