### PR TITLE
feat(non-github scm): Initial sounding-out of non-github SCM support

### DIFF
--- a/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
@@ -24,6 +24,9 @@ scms:
   default:
     kind: {{ default "github" .scm.kind }}
     spec:
+# {{ if .scm.url }}
+      url: {{ .scm.url }}
+# {{ end }}
       # Priority set to the environment variable
       user: '{{ default $GitHubUser .scm.user}}'
 # {{ if .scm.email }}

--- a/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
@@ -22,7 +22,7 @@ autodiscovery:
 {{ if or (.scm.enabled) (env "GITHUB_REPOSITORY") }}
 scms:
   default:
-    kind: "github"
+    kind: {{ default "github" .scm.kind }}
     spec:
       # Priority set to the environment variable
       user: '{{ default $GitHubUser .scm.user}}'
@@ -40,10 +40,12 @@ scms:
 
 actions:
   default:
-    kind: "github/pullrequest"
+    kind: {{ default "github/pullrequest" .action.kind }}
     scmid: "default"
     spec:
+# {{ if .automerge }}
       automerge: {{ .automerge }}
+# {{ end }}
 # {{ if .labels }}
       labels:
 # {{ range .labels }}

--- a/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
+++ b/updatecli/policies/golang/autodiscovery/updatecli.d/default.tpl
@@ -34,7 +34,11 @@ scms:
 # {{ end }}
       owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
       repository: '{{ default $GitHubRepositoryList._1 .scm.repository}}'
+# {{ if .scm.token_env }}
+      token: '{{ env .scm.token_env }}'
+# {{ else }}
       token: '{{ default $GitHubPAT .scm.token }}'
+# {{ end }}
       username: '{{ default $GitHubUsername .scm.username }}'
       branch: '{{ .scm.branch }}'
 #{{ if .scm.commitusingapi }}

--- a/updatecli/policies/golang/autodiscovery/values.yaml
+++ b/updatecli/policies/golang/autodiscovery/values.yaml
@@ -4,8 +4,10 @@ automerge: false
 labels:
   - dependencies
 
+
 scm:
   enabled: false
+  # kind: github
   # user: updatecli-bot
   # email: updatecli-bot@updatecli.io
   # owner: updatecli
@@ -13,6 +15,9 @@ scm:
   # token: "xxx"
   # username: "updatecli-bot"
   # branch: main
+
+action:
+  kind: github/pullrequest
 
 # spec:
 groupby: all

--- a/updatecli/policies/golang/autodiscovery/values.yaml
+++ b/updatecli/policies/golang/autodiscovery/values.yaml
@@ -8,6 +8,7 @@ labels:
 scm:
   enabled: false
   # kind: github
+  # url: https://github.com
   # user: updatecli-bot
   # email: updatecli-bot@updatecli.io
   # owner: updatecli

--- a/updatecli/policies/golang/autodiscovery/values.yaml
+++ b/updatecli/policies/golang/autodiscovery/values.yaml
@@ -14,6 +14,7 @@ scm:
   # owner: updatecli
   # repository: updatecli
   # token: "xxx"
+  # token_env: "UPDATECLI_SCM_TOKEN"
   # username: "updatecli-bot"
   # branch: main
 


### PR DESCRIPTION
<!-- Provide a link to the issue you are solving in this pull request -->
Example alternate solution to https://github.com/updatecli/updatecli/issues/5461
## Description
This PR is an example of how I think we could easily make non-github SCMs work for this repo.

## Test
To use this on, for example, codeberg.org:

```
scm:
  enabled: true
  kind: gitea
  url: https://codeberg.org
  username: your-updatecli-bot
  token_env: UPDATECLI_CODEBERG_TOKEN
  owner: some
  repository: repo
  branch: main

labels: false
automerge: false

action:
  kind: gitea/pullrequest
```

## Additional Information

### Tradeoff
This makes the configuration somewhat more complex for non-github users, but it doesn't break existing github users. ( At least, it shouldn't, unless I missed something)

### Potential improvement
This should allow any SCM to be used that is supported by updatecli, without a bunch of if-else's for different SCMs
