### PR TITLE
fix: remove space from GitHub action label def

### DIFF
--- a/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/cargo/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/cargo/Policy.yaml
+++ b/updatecli/policies/autodiscovery/cargo/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/cargo/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/cargo/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/cargo/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/cargo/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/cargo/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/dockercompose/Policy.yaml
+++ b/updatecli/policies/autodiscovery/dockercompose/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockercompose/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockercompose/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockercompose/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/dockercompose/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/dockercompose/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/dockerfile/Policy.yaml
+++ b/updatecli/policies/autodiscovery/dockerfile/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockerfile/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockerfile/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/dockerfile/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/dockerfile/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/dockerfile/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/flux/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/flux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/flux/Policy.yaml
+++ b/updatecli/policies/autodiscovery/flux/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/flux/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/flux/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/flux/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/flux/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/flux/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/githubaction/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+* Remove space from GitHub action label definition
+
 ## 0.2.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/githubaction/Policy.yaml
+++ b/updatecli/policies/autodiscovery/githubaction/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/githubaction/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/githubaction/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/githubaction/"
-version: 0.2.0
+version: 0.2.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/githubaction/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/githubaction/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/golang/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/golang/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.1
+
+* Remove space from GitHub action label definition
+
 ## 0.11.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/golang/Policy.yaml
+++ b/updatecli/policies/autodiscovery/golang/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/golang/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/golang/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/golang/"
-version: 0.11.0
+version: 0.11.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/golang/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/golang/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/helm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/helm/Policy.yaml
+++ b/updatecli/policies/autodiscovery/helm/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helm/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helm/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helm/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/helm/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/helm/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1
+
+* Remove space from GitHub action label definition
+
 ## 0.6.0
 
 * Configure Pull Request GitHub labels using `labels`.

--- a/updatecli/policies/autodiscovery/helmfile/Policy.yaml
+++ b/updatecli/policies/autodiscovery/helmfile/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helmfile/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helmfile/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/helmfile/"
-version: 0.6.0
+version: 0.6.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/helmfile/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/helmfile/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/ko/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/ko/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/ko/Policy.yaml
+++ b/updatecli/policies/autodiscovery/ko/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/ko/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/ko/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/ko/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/ko/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/ko/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/kubernetes/Policy.yaml
+++ b/updatecli/policies/autodiscovery/kubernetes/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/kubernetes/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/kubernetes/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/kubernetes/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/kubernetes/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/kubernetes/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/maven/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/maven/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/maven/Policy.yaml
+++ b/updatecli/policies/autodiscovery/maven/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/maven/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/maven/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/maven/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/maven/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/maven/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/npm/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/npm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+* Remove space from GitHub action label definition
+
 ## 0.12.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/npm/Policy.yaml
+++ b/updatecli/policies/autodiscovery/npm/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/npm/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/npm/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/npm/"
-version: 0.12.0
+version: 0.12.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/npm/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/npm/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/precommit/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/precommit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+* Remove space from GitHub action label definition
+
 ## 0.2.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/precommit/Policy.yaml
+++ b/updatecli/policies/autodiscovery/precommit/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/precommit/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/precommit/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/precommit/"
-version: 0.2.0
+version: 0.2.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/precommit/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/precommit/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/prow/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/prow/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1
+
+* Remove space from GitHub action label definition
+
 ## 0.4.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/prow/Policy.yaml
+++ b/updatecli/policies/autodiscovery/prow/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/prow/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/prow/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/prow/"
-version: 0.4.0
+version: 0.4.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/prow/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/prow/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/rancher/fleet/Policy.yaml
+++ b/updatecli/policies/autodiscovery/rancher/fleet/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/rancher/fleet/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/rancher/fleet/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/rancher/fleet/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/rancher/fleet/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/rancher/fleet/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/terraform/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+* Remove space from GitHub action label definition
+
 ## 0.7.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/terraform/Policy.yaml
+++ b/updatecli/policies/autodiscovery/terraform/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terraform/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terraform/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terraform/"
-version: 0.7.0
+version: 0.7.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/terraform/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/terraform/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/terragrunt/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/terragrunt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1
+
+* Remove space from GitHub action label definition
+
 ## 0.4.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/terragrunt/Policy.yaml
+++ b/updatecli/policies/autodiscovery/terragrunt/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terragrunt/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terragrunt/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/terragrunt/"
-version: 0.4.0
+version: 0.4.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/terragrunt/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/terragrunt/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+* Remove space from GitHub action label definition
+
 ## 0.9.0
 
 ! Require Updatecli 0.103.0

--- a/updatecli/policies/autodiscovery/updatecli/Policy.yaml
+++ b/updatecli/policies/autodiscovery/updatecli/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/updatecli/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/updatecli/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/updatecli/"
-version: 0.9.0
+version: 0.9.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/autodiscovery/updatecli/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/updatecli/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/file/CHANGELOG.md
+++ b/updatecli/policies/file/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.1
+
+* Remove space from GitHub action label definition
+
 ## 0.2.0
 
   * Allow to use the policy without pushing to a git repository

--- a/updatecli/policies/file/Policy.yaml
+++ b/updatecli/policies/file/Policy.yaml
@@ -15,8 +15,8 @@ documentation: "https://github.com/updatecli/policies/tree/main/updatecli/polici
 # Source is the policy source URL
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/file/"
 
-# Version is the policy version. 
-version: 0.2.0
+# Version is the policy version.
+version: 0.2.1
 
 # Vendor is the policy vendor
 vendor: Updatecli project

--- a/updatecli/policies/file/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/file/updatecli.d/_scm.github.yaml
@@ -19,7 +19,7 @@ actions:
             # {{ if .pr.labels }}
             labels:
                 # {{ range .pr.labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/golang/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/golang/autodiscovery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.1
+
+* Remove space from GitHub action label definition
+
 ## 0.10.0
 
 * Add policy support Gitea, Gitlab, Stash, Bitbucket

--- a/updatecli/policies/golang/autodiscovery/Policy.yaml
+++ b/updatecli/policies/golang/autodiscovery/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/autodiscovery/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/autodiscovery/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/autodiscovery/"
-version: 0.10.0
+version: 0.10.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/golang/autodiscovery/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/golang/autodiscovery/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/golang/version/CHANGELOG.md
+++ b/updatecli/policies/golang/version/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+* Remove space from GitHub action label definition
+
 ## 0.5.0
 
 ! Require Updatecli version 0.103.0

--- a/updatecli/policies/golang/version/Policy.yaml
+++ b/updatecli/policies/golang/version/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/version/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/version/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golang/version/"
-version: 0.5.0
+version: 0.5.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/golang/version/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/golang/version/updatecli.d/_scm.github.yaml
@@ -12,7 +12,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
+++ b/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1
+
+* Remove space from GitHub action label definition
+
 ## 0.6.0
 
 ! Require Updatecli v0.103.0

--- a/updatecli/policies/golangci-lint/githubaction/Policy.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golangci-lint/githubaction/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golangci-lint/githubaction/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/golangci-lint/githubaction/"
-version: 0.6.0
+version: 0.6.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/golangci-lint/githubaction/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/golangci-lint/githubaction/updatecli.d/_scm.github.yaml
@@ -12,7 +12,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/hugo/githubaction/CHANGELOG.md
+++ b/updatecli/policies/hugo/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+* Remove space from GitHub action label definition
+
 ## 0.9.0
 
 ! Require Updatecli v0.103.0

--- a/updatecli/policies/hugo/githubaction/Policy.yaml
+++ b/updatecli/policies/hugo/githubaction/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/githubaction/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/githubaction/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/githubaction/"
-version: 0.9.0
+version: 0.9.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/hugo/githubaction/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/hugo/githubaction/updatecli.d/_scm.github.yaml
@@ -12,7 +12,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/hugo/netlify/CHANGELOG.md
+++ b/updatecli/policies/hugo/netlify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+* Remove space from GitHub action label definition
+
 ## 0.8.0
 
 ! Require Updatecli v0.103.0

--- a/updatecli/policies/hugo/netlify/Policy.yaml
+++ b/updatecli/policies/hugo/netlify/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/netlify/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/netlify/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/hugo/netlify/"
-version: 0.8.0
+version: 0.8.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/hugo/netlify/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/hugo/netlify/updatecli.d/_scm.github.yaml
@@ -12,7 +12,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/nodejs/githubaction/CHANGELOG.md
+++ b/updatecli/policies/nodejs/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+* Remove space from GitHub action label definition
+
 ## 0.9.0
 
 ! Require Updatecli v0.103.0

--- a/updatecli/policies/nodejs/githubaction/Policy.yaml
+++ b/updatecli/policies/nodejs/githubaction/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/githubaction/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/githubaction/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/githubaction/"
-version: 0.9.0
+version: 0.9.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/nodejs/githubaction/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/nodejs/githubaction/updatecli.d/_scm.github.yaml
@@ -12,7 +12,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/nodejs/netlify/CHANGELOG.md
+++ b/updatecli/policies/nodejs/netlify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+* Remove space from GitHub action label definition
+
 ## 0.8.0
 
 ! Require Updatecli v0.103.0

--- a/updatecli/policies/nodejs/netlify/Policy.yaml
+++ b/updatecli/policies/nodejs/netlify/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/netlify/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/netlify/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/nodejs/netlify/"
-version: 0.8.0
+version: 0.8.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/nodejs/netlify/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/nodejs/netlify/updatecli.d/_scm.github.yaml
@@ -12,7 +12,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/npm/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/npm/autodiscovery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.1
+
+* Remove space from GitHub action label definition
+
 ## 0.10.0
 
 ! Require Updatecli 0.103.0 or later

--- a/updatecli/policies/npm/autodiscovery/Policy.yaml
+++ b/updatecli/policies/npm/autodiscovery/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/autodiscovery/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/autodiscovery/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/autodiscovery/"
-version: 0.10.0
+version: 0.10.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/npm/autodiscovery/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/npm/autodiscovery/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/npm/netlify/CHANGELOG.md
+++ b/updatecli/policies/npm/netlify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+* Remove space from GitHub action label definition
+
 ## 0.9.0
 
 ! Require Updatecli 0.103.0 or later

--- a/updatecli/policies/npm/netlify/Policy.yaml
+++ b/updatecli/policies/npm/netlify/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/netlify/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/netlify/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/npm/netlify/"
-version: 0.9.0
+version: 0.9.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/npm/netlify/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/npm/netlify/updatecli.d/_scm.github.yaml
@@ -12,7 +12,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/rancher/fleet/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/rancher/fleet/autodiscovery/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+* Remove space from GitHub action label definition
+
 ## 0.5.0
 
 ! Require Updatecli 0.103.0 or later

--- a/updatecli/policies/rancher/fleet/autodiscovery/Policy.yaml
+++ b/updatecli/policies/rancher/fleet/autodiscovery/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/rancher/fleet/autodiscovery/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/rancher/fleet/autodiscovery/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/rancher/fleet/autodiscovery/"
-version: 0.5.0
+version: 0.5.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/rancher/fleet/autodiscovery/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/rancher/fleet/autodiscovery/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/releasepost/releasepost/CHANGELOG.md
+++ b/updatecli/policies/releasepost/releasepost/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+* Remove space from GitHub action label definition
+
 ## 0.9.0
 
 ! Require Updatecli 0.103.0 or later

--- a/updatecli/policies/releasepost/releasepost/Policy.yaml
+++ b/updatecli/policies/releasepost/releasepost/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/releasepost/releasepost/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/releasepost/releasepost/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/releasepost/releasepost/"
-version: 0.9.0
+version: 0.9.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/releasepost/releasepost/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/releasepost/releasepost/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"

--- a/updatecli/policies/updatecli/autodiscovery/CHANGELOG.md
+++ b/updatecli/policies/updatecli/autodiscovery/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## 0.6.1
+
+* Remove space from GitHub action label definition
+
 ## 0.6.0
 
 ! Require Updatecli 0.103.0 or later

--- a/updatecli/policies/updatecli/autodiscovery/Policy.yaml
+++ b/updatecli/policies/updatecli/autodiscovery/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/autodiscovery/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/autodiscovery/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/autodiscovery/"
-version: 0.6.0
+version: 0.6.1
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/updatecli/autodiscovery/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/updatecli/autodiscovery/updatecli.d/_scm.github.yaml
@@ -11,7 +11,7 @@ actions:
             # {{ if .labels }}
             labels:
                 # {{ range .labels }}
-                - ' {{ . }}'
+                - '{{ . }}'
                 # {{ end }}
             # {{ end }}
             mergemethod: "squash"


### PR DESCRIPTION
Fix a regression issue where I inserted a space in the label definition

## Description

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
make test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
