### PR TITLE
Fix GHCR path format in docgen.py

### DIFF
--- a/.ci/scripts/docgen.py
+++ b/.ci/scripts/docgen.py
@@ -43,7 +43,7 @@ def generate_markdown_table(policies: List[PolicyMetadata]) -> str:
         description = p.description.replace("\n", " ").strip()
         ghcr_path = f"ghcr.io/{os.path.normpath(os.path.dirname(p.path))}"
         readme_url = replace_filename_in_url(f"https://github.com/updatecli/policies/tree/main/{p.path}", "README.md")
-        rows.append(f"| `{ghcr_path}@{p.version}` | {description or '-'} | {f"[link]({readme_url})" } |")
+        rows.append(f"| `{ghcr_path}:{p.version}` | {description or '-'} | {f"[link]({readme_url})" } |")
     return header + separator + "\n".join(rows)
 
 def replace_filename_in_url(url: str, new_filename: str) -> str:


### PR DESCRIPTION
The generated url is just wrong