### PR TITLE
feat: customize zizmor policy commit message

### DIFF
--- a/updatecli/policies/zizmor/githubaction/scaffold/CHANGELOG.md
+++ b/updatecli/policies/zizmor/githubaction/scaffold/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.4.0
+
+* Allow to use shallow clone with the parameter depth
+* Allow to customize the commit message
+* Allow to target parent repository
+
 ## 0.3.2
 
 * Fix space between comment and gha action version

--- a/updatecli/policies/zizmor/githubaction/scaffold/Policy.yaml
+++ b/updatecli/policies/zizmor/githubaction/scaffold/Policy.yaml
@@ -26,7 +26,7 @@ documentation: "https://github.com/updatecli/policies/tree/main/updatecli/polici
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/zizmor/githubaction/scaffold/"
 
 # Version: policy version (prefer semver, e.g. 1.0.0). Recommended.
-version: 0.3.2
+version: 0.4.0
 
 # Vendor: organization or maintainer (optional).
 vendor: Updatecli Project

--- a/updatecli/policies/zizmor/githubaction/scaffold/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/zizmor/githubaction/scaffold/updatecli.d/_scm.github.yaml
@@ -55,7 +55,7 @@ scms:
       commitmessage:
         type: "{{ .scm.commitmessage.type }}"
         scope: "{{ .scm.commitmessage.scope }}"
-        # {{ if .scm.commitmessage.footers}}
+        # {{ if .scm.commitmessage.footers }}
         footers: "{{ .scm.commitmessage.footers }}"
         # {{ end }}
 # {{ end }}

--- a/updatecli/policies/zizmor/githubaction/scaffold/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/zizmor/githubaction/scaffold/updatecli.d/_scm.github.yaml
@@ -23,6 +23,7 @@ actions:
       # {{ end }}
       mergemethod: "squash"
       description: "{{ .description }}"
+      parent: {{ .parent }}
     scmid: "default"
 
 scms:
@@ -48,5 +49,13 @@ scms:
       # {{ if .scm.url }}
       url: "{{ .scm.url }}"
       # {{ end }}
+      # {{ if .scm.depth }}
+      depth: {{ .scm.depth }}
+      # {{ end }}
+      commitmessage:
+        type: "{{ .scm.commitmessage.type }}"
+        scope: "{{ .scm.commitmessage.scope }}"
+        # {{ if .scm.commitmessage.footers}}
+        footers: "{{ .scm.commitmessage.footers }}"
+        # {{ end }}
 # {{ end }}
-

--- a/updatecli/policies/zizmor/githubaction/scaffold/updatecli.d/_scm.githubsearch.yaml
+++ b/updatecli/policies/zizmor/githubaction/scaffold/updatecli.d/_scm.githubsearch.yaml
@@ -15,6 +15,7 @@ actions:
       # {{ end }}
       mergemethod: "squash"
       description: "{{ .description }}"
+      parent: {{ .parent }}
     scmid: "default"
 scms:
   default:
@@ -40,4 +41,14 @@ scms:
       # {{ if .scm.url }}
       url: "{{ .scm.url }}"
       # {{ end }}
+      # {{ if .scm.depth }}
+      depth: {{ .scm.depth }}
+      # {{ end }}
+      commitmessage:
+        type: "{{ .scm.commitmessage.type }}"
+        scope: "{{ .scm.commitmessage.scope }}"
+        # {{ if .scm.commitmessage.footers }}
+        footers: "{{ .scm.commitmessage.footers }}"
+        # {{ end }}
 # {{ end }}
+

--- a/updatecli/policies/zizmor/githubaction/scaffold/updatecli.d/default.yaml
+++ b/updatecli/policies/zizmor/githubaction/scaffold/updatecli.d/default.yaml
@@ -47,8 +47,8 @@ sources:
         pattern: '{{ source "checkout-action" }}'
 
 targets:
-  zizmor.yaml:
-    name: Scaffold Zizmor action
+  workflow:
+    name: 'install Zizmor gha action {{ source "zizmor-action" }}'
     kind: file
     disablesourceinput: true
     # {{ if .scm.enabled }}

--- a/updatecli/policies/zizmor/githubaction/scaffold/values.yaml
+++ b/updatecli/policies/zizmor/githubaction/scaffold/values.yaml
@@ -28,12 +28,25 @@ scm:
   # email: updatecli-bot@example.com
   # branch: main
 
+  commitusingapi: true
+
   limit: 3
+  # depth controls how many commits are fetched when Updatecli interacts with the SCM. A lower depth can speed up operations but may limit the ability to access historical commit.
+  # Adjust based on your needs. Default shallow clone disabled.
+  depth: 0
+  commitmessage:
+    type: "chore"
+    scope: "zizmor"
+    #footers: "Signed-off-by: updateclibot <bot@updatecli.io"
 # Example: to disable SCM during local dry-runs, set `scm.enabled: false`.
 #
 
 pipelineid: scaffold_zizmor
 automerge: false
+# Parent is a boolean that controls whether the generated PR should target the parent of the repository or the repository itself.
+# This is useful when the repository is a fork and you want to target the upstream repository instead of the fork.
+# Default is false, meaning the PR will target the repository itself.
+parent: false
 labels:
   - "chore"
 

--- a/updatecli/policies/zizmor/githubaction/scaffold/values.yaml
+++ b/updatecli/policies/zizmor/githubaction/scaffold/values.yaml
@@ -37,7 +37,7 @@ scm:
   commitmessage:
     type: "chore"
     scope: "zizmor"
-    #footers: "Signed-off-by: updateclibot <bot@updatecli.io"
+    #footers: "Signed-off-by: updateclibot <bot@updatecli.io>"
 # Example: to disable SCM during local dry-runs, set `scm.enabled: false`.
 #
 


### PR DESCRIPTION
## Description

* Allow to use shallow clone with the parameter depth
* Allow to customize the commit message
* Allow to target parent repository

## Test

To test this pull request, you can run the following commands:

```shell
cp updatecli/policies/zizmor/githubaction/scaffold
updatecli diff --config updatecli.d --values values.yaml --values testdata/values.yaml
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
