### PR TITLE
feat(pyproject): init autodiscovery policy

### DIFF
--- a/updatecli/policies/autodiscovery/pyproject/CHANGELOG.md
+++ b/updatecli/policies/autodiscovery/pyproject/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+* init policy

--- a/updatecli/policies/autodiscovery/pyproject/Policy.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/Policy.yaml
@@ -1,0 +1,15 @@
+authors:
+  - Loïs Postula
+
+url: "https://github.com/updatecli/policies/"
+documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/pyproject/README.md"
+changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/pyproject/CHANGELOG.md"
+source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/autodiscovery/pyproject/"
+version: 0.1.0
+vendor: Updatecli Project
+
+licenses:
+  - "Apache-2.0 license"
+
+description: |
+  Pyproject Autodiscovery

--- a/updatecli/policies/autodiscovery/pyproject/README.md
+++ b/updatecli/policies/autodiscovery/pyproject/README.md
@@ -1,0 +1,216 @@
+# pyproject Autodiscovery Policy
+
+Automatically discover and update Python package dependencies across repositories by scanning `pyproject.toml` files.
+
+## Overview
+
+This policy builds an Updatecli pipeline with one autodiscovery crawler:
+
+- `pyproject`
+
+The generated pipeline can:
+
+- detect Python package dependency updates from `pyproject.toml`
+- group discovered updates according to your `groupby` setting
+- apply changes locally, or create pull requests when SCM is enabled
+
+The policy does not hardcode dependency rules. Instead, it passes your `spec` values directly to the pyproject autodiscovery crawler so you can tune behavior with the same options supported by the Updatecli pyproject autodiscovery plugin.
+
+## Requirements
+
+- `updatecli` CLI installed
+- access to an OCI registry if you want to publish or consume the bundle from a registry
+- optional: `docker` or another OCI client for registry authentication
+- SCM credentials when `scm.enabled: true`
+
+## Supported SCM Backends
+
+When SCM support is enabled, this policy can create pull requests or merge requests using:
+
+- `github`
+- `githubsearch`
+- `gitlab`
+- `gitea`
+- `bitbucket`
+- `stash`
+
+The default `scm.env_token` value is `GITHUB_TOKEN`. For non-GitHub providers, set `scm.env_token` to the environment variable that contains the correct token for that platform.
+
+## Policy Configuration
+
+### Available Input Values
+
+The default `values.yaml` exposes these top-level inputs:
+
+- `name`: pipeline name (defaults to `deps(pyproject): bump all dependencies`)
+- `pipelineid`: optional pipeline identifier
+- `automerge`: controls GitHub and GitHub search pull request automerge behavior
+- `labels`: labels applied on GitHub and GitHub search pull requests
+- `groupby`: autodiscovery grouping strategy
+- `scm`: optional SCM configuration used to open pull requests (defaults to `enabled: false`)
+- `pipeline.labels`: additional labels applied to the generated pipeline metadata
+
+### Example Values
+
+The following example updates pyproject packages and opens one pull request per detected update:
+
+```yaml
+pipelineid: "pyproject_autodiscovery"
+groupby: individual
+automerge: false
+
+labels:
+  - dependencies
+  - python
+
+scm:
+  enabled: true
+  kind: github
+  env_token: GITHUB_TOKEN
+  user: updatecli-bot
+  email: updatecli-bot@example.com
+  owner: myorg
+  repository: myrepo
+  username: updatecli-bot
+  branch: main
+```
+
+To target multiple GitHub repositories discovered by search instead of a single repository, switch the SCM kind to `githubsearch`:
+
+```yaml
+scm:
+  enabled: true
+  kind: githubsearch
+  env_token: GITHUB_TOKEN
+  search: |
+    org:myorg
+    archived:false
+    fork:false
+  branch: main
+  username: updatecli-bot
+  email: updatecli-bot@example.com
+  limit: 3
+```
+
+## How It Works
+
+This policy renders a manifest equivalent to the following structure:
+
+```yaml
+pipelineid: <pipelineid>
+
+autodiscovery:
+  groupby: <groupby>
+  scmid: default
+  actionid: default
+  crawlers:
+    pyproject:
+      <spec>
+```
+
+If `scm.enabled` is `false`, the pipeline runs without any SCM or pull request action and applies changes locally.
+
+If `scm.enabled` is `true`, the policy also injects a `default` SCM and `default` action matching the selected SCM provider.
+
+## Quick Usage
+
+### Local Testing
+
+Show the rendered manifest:
+
+```sh
+updatecli manifest show --config updatecli.d --values values.yaml
+```
+
+Run a dry-run:
+
+```sh
+updatecli pipeline diff --config updatecli.d --values values.yaml
+```
+
+Apply the policy locally or through the configured SCM action:
+
+```sh
+updatecli pipeline apply --config updatecli.d --values values.yaml
+```
+
+### Using from an OCI Registry
+
+Consume the published bundle directly from a registry:
+
+```sh
+updatecli manifest show --values values.yaml ghcr.io/updatecli/policies/autodiscovery/pyproject:0.1.0
+```
+
+```sh
+updatecli pipeline diff --values values.yaml ghcr.io/updatecli/policies/autodiscovery/pyproject:0.1.0
+```
+
+```sh
+updatecli pipeline apply --values values.yaml ghcr.io/updatecli/policies/autodiscovery/pyproject:0.1.0
+```
+
+## Authentication
+
+Authenticate to your OCI registry before pushing or pulling bundles:
+
+```sh
+docker login "$OCI_REGISTRY"
+```
+
+When using SCM integration, export the token referenced by `scm.env_token` before running Updatecli.
+
+## Publish
+
+Publish this policy bundle to an OCI registry. The `version` field in `Policy.yaml` defines the bundle tag:
+
+```sh
+updatecli manifest push \
+  --config updatecli.d \
+  --values values.yaml \
+  --policy Policy.yaml \
+  --tag "$OCI_REGISTRY/autodiscovery/pyproject" \
+  .
+```
+
+After publishing, reference the bundle by tag:
+
+```sh
+updatecli manifest show "$OCI_REGISTRY/autodiscovery/pyproject:0.1.0"
+```
+
+## Troubleshooting
+
+### No updates detected
+
+1. Show the rendered manifest and verify that the `pyproject` crawler is present:
+
+   ```sh
+   updatecli manifest show --config updatecli.d --values values.yaml
+   ```
+
+2. Confirm that the repository contains `pyproject.toml` files at the expected paths.
+
+3. Run in debug mode:
+
+   ```sh
+   updatecli pipeline diff --log-level debug --config updatecli.d --values values.yaml
+   ```
+
+### Pull requests are not created
+
+1. Confirm `scm.enabled: true` and that the correct `scm.kind` is configured.
+
+2. Verify that the token environment variable referenced by `scm.env_token` is exported.
+
+3. Confirm repository targeting values such as `owner`, `repository`, `branch`, or `search`.
+
+4. For GitHub and GitHub search, remember that `labels` and `automerge` are applied only when the policy creates GitHub pull requests.
+
+## Related Documentation
+
+- Updatecli docs: <https://www.updatecli.io>
+- Autodiscovery docs: <https://www.updatecli.io/docs/core/autodiscovery/>
+- Compose docs: <https://www.updatecli.io/docs/core/compose/>
+- Sharing and reuse: <https://www.updatecli.io/docs/core/shareandreuse/>
+- Updatecli policies repository: <https://github.com/updatecli/policies>

--- a/updatecli/policies/autodiscovery/pyproject/testdata/values.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/testdata/values.yaml
@@ -1,0 +1,8 @@
+scm:
+  enabled: true
+  user: updatecli-bot
+  email: updatecli-bot@updatecli.io
+  owner: updatecli
+  repository: website
+  username: "updatecli-bot"
+  branch: master

--- a/updatecli/policies/autodiscovery/pyproject/updatecli.d/_labels.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/updatecli.d/_labels.yaml
@@ -1,0 +1,4 @@
+labels:
+  #{{- range $key, $value := .pipeline.labels }}
+  '{{ $key }}': '{{ $value }}'
+  #{{- end }}

--- a/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.bitbucket.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.bitbucket.yaml
@@ -1,0 +1,21 @@
+# {{ if and .scm.enabled ( eq .scm.kind "bitbucket") }}
+# {{ $GitbucketPAT := env .scm.env_token }}
+actions:
+    default:
+        kind: "bitbucket/pullrequest"
+        scmid: "default"
+
+scms:
+    default:
+        kind: "bitbucket"
+        spec:
+            user: '{{ .scm.user }}'
+            # {{ if .scm.email }}
+            email: '{{ .scm.email }}'
+            # {{ end }}
+            owner: '{{ .scm.owner }}'
+            repository: '{{ .scm.repository }}'
+            token: '{{ default $GitbucketPAT .scm.token }}'
+            username: '{{ .scm.username }}'
+            branch: '{{ .scm.branch }}'
+# {{ end }}

--- a/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.gitea.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.gitea.yaml
@@ -1,0 +1,24 @@
+# {{ if and .scm.enabled ( eq .scm.kind "gitea") }}
+# {{ $GiteaPAT := env .scm.env_token }}
+actions:
+    default:
+        kind: "gitea/pullrequest"
+        scmid: "default"
+
+scms:
+    default:
+        kind: "gitea"
+        spec:
+            user: '{{ .scm.user }}'
+            # {{ if .scm.email }}
+            email: '{{ .scm.email }}'
+            # {{ end }}
+            owner: '{{ .scm.owner }}'
+            repository: '{{ .scm.repository }}'
+            token: '{{ default $GiteaPAT .scm.token }}'
+            username: '{{ .scm.username }}'
+            branch: '{{ .scm.branch }}'
+            # {{ if .scm.url }}
+            url: '{{ .scm.url }}'
+            # {{ end }}
+# {{ end }}

--- a/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.github.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.github.yaml
@@ -1,0 +1,39 @@
+# {{ if and .scm.enabled ( eq .scm.kind "github" ) }}
+# {{ $GitHubUser := env ""}}
+# {{ $GitHubUsername := env "GITHUB_ACTOR"}}
+# {{ $GitHubPAT := env .scm.env_token }}
+# {{ $GitHubRepositoryList := env "GITHUB_REPOSITORY" | split "/"}}
+actions:
+    default:
+        kind: "github/pullrequest"
+        spec:
+            automerge: {{.automerge}}
+            # {{ if .labels }}
+            labels:
+                # {{ range .labels }}
+                - '{{ . }}'
+                # {{ end }}
+            # {{ end }}
+            mergemethod: "squash"
+        scmid: "default"
+scms:
+    default:
+        kind: "github"
+        spec:
+            # Priority set to the environment variable
+            user: '{{ default $GitHubUser .scm.user }}'
+            # {{ if .scm.email }}
+            email: '{{ .scm.email }}'
+            # {{ end }}
+            owner: '{{ default $GitHubRepositoryList._0 .scm.owner }}'
+            repository: '{{ default $GitHubRepositoryList._1 .scm.repository }}'
+            token: '{{ default $GitHubPAT .scm.token }}'
+            username: '{{ default $GitHubUsername  .scm.username }}'
+            branch: '{{ .scm.branch }}'
+            # {{ if .scm.commitusingapi }}
+            commitusingapi: {{.scm.commitusingapi}}
+            # {{ end }}
+            # {{ if .scm.url }}
+            url: '{{ .scm.url }}'
+            # {{ end }}
+# {{ end }}

--- a/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.githubsearch.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.githubsearch.yaml
@@ -1,0 +1,40 @@
+# {{ if and .scm.enabled ( eq .scm.kind "githubsearch" ) }}
+# {{ $GitHubUser := env "GITHUB_ACTOR"}}
+# {{ $GitHubUsername := env "GITHUB_ACTOR"}}
+# {{ $GitHubPAT := env .scm.env_token }}
+actions:
+    default:
+        kind: "github/pullrequest"
+        spec:
+            automerge: {{.automerge}}
+            # {{ if .labels }}
+            labels:
+                # {{ range .labels }}
+                - '{{ . }}'
+                # {{ end }}
+            # {{ end }}
+            mergemethod: "squash"
+        scmid: "default"
+scms:
+    default:
+        kind: "githubsearch"
+        spec:
+            # Priority set to the environment variable
+            user: '{{ default $GitHubUser .scm.user }}'
+            # {{ if .scm.email }}
+            email: '{{ .scm.email }}'
+            # {{ end }}
+            search: '{{ .scm.search }}'
+            # {{ if kindIs "int" .scm.limit }}
+            limit: {{ .scm.limit }}
+            # {{ end }}
+            token: '{{ default $GitHubPAT .scm.token }}'
+            username: '{{ default $GitHubUsername  .scm.username }}'
+            branch: '{{ .scm.branch }}'
+            # {{ if .scm.commitusingapi }}
+            commitusingapi: {{.scm.commitusingapi}}
+            # {{ end }}
+            # {{ if .scm.url }}
+            url: '{{ .scm.url }}'
+            # {{ end }}
+# {{ end }}

--- a/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.gitlab.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.gitlab.yaml
@@ -1,0 +1,24 @@
+# {{ if and .scm.enabled ( eq .scm.kind "gitlab") }}
+# {{ $GitlabPAT := env .scm.env_token }}
+actions:
+    default:
+        kind: "gitlab/mergerequest"
+        scmid: "default"
+
+scms:
+    default:
+        kind: "gitlab"
+        spec:
+            user: '{{ .scm.user }}'
+            # {{ if .scm.email }}
+            email: '{{ .scm.email }}'
+            # {{ end }}
+            owner: '{{ .scm.owner }}'
+            repository: '{{ .scm.repository }}'
+            token: '{{ default $GitlabPAT .scm.token }}'
+            username: '{{ .scm.username }}'
+            branch: '{{ .scm.branch }}'
+            # {{ if .scm.url }}
+            url: '{{ .scm.url }}'
+            # {{ end }}
+# {{ end }}

--- a/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.stash.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/updatecli.d/_scm.stash.yaml
@@ -1,0 +1,24 @@
+# {{ if and .scm.enabled ( eq .scm.kind "stash") }}
+# {{ $StashPAT := env .scm.env_token }}
+actions:
+    default:
+        kind: "stash/pullrequest"
+        scmid: "default"
+
+scms:
+    default:
+        kind: "stash"
+        spec:
+            user: '{{ .scm.user }}'
+            # {{ if .scm.email }}
+            email: '{{ .scm.email }}'
+            # {{ end }}
+            owner: '{{ .scm.owner }}'
+            repository: '{{ .scm.repository }}'
+            token: '{{ default $StashPAT .scm.token }}'
+            username: '{{ .scm.username }}'
+            branch: '{{ .scm.branch }}'
+            # {{ if .scm.url }}
+            url: '{{ .scm.url }}'
+            # {{ end }}
+# {{ end }}

--- a/updatecli/policies/autodiscovery/pyproject/updatecli.d/default.tpl
+++ b/updatecli/policies/autodiscovery/pyproject/updatecli.d/default.tpl
@@ -1,0 +1,16 @@
+name: '{{ .name }}'
+version: "0.116.1"
+#{{ if .pipelineid }}
+pipelineid: '{{ .pipelineid }}'
+#{{ end }}
+
+autodiscovery:
+  groupby: {{ .groupby }}
+  #{{ if .scm.enabled }}
+  scmid: default
+  actionid: default
+  # {{ end }}
+
+  crawlers:
+    pyproject:
+{{ .spec | toYaml | indent 6 }}

--- a/updatecli/policies/autodiscovery/pyproject/values.yaml
+++ b/updatecli/policies/autodiscovery/pyproject/values.yaml
@@ -1,0 +1,32 @@
+name: "deps(pyproject): bump all dependencies"
+#pipelineid: pyproject/autodiscovery
+automerge: false
+labels:
+  - dependencies
+
+autodiscovery:
+  groupby: all
+
+scm:
+  enabled: false
+  ## kind defines the SCM kind to use for this policy
+  ## Accepted values: github, gitea, bitbucket, gitlab, stash
+  kind: github
+  ## env_token defines the environment variable to use to retrieve the token
+  env_token: GITHUB_TOKEN
+  # user: updatecli-bot
+  # email: updatecli-bot@updatecli.io
+  # owner: updatecli
+  # repository: updatecli
+  # token: "xxx"
+  # username: "updatecli-bot"
+  # branch: main
+  limit: 3
+
+# spec:
+groupby: all
+
+pipeline:
+  labels:
+    ecosystem: "python"
+    policy: autodiscovery


### PR DESCRIPTION
## Summary
- Add pyproject crawler autodiscovery policy for discovering and updating Python package dependencies from `pyproject.toml` files
- Follows the established `autodiscovery/<ecosystem>/` policy structure with all 6 SCM backends (github, githubsearch, gitlab, gitea, bitbucket, stash)
- Includes configurable values, template, README, changelog, and testdata

## Test plan
- [ ] `updatecli manifest show --config updatecli.d --values values.yaml` renders correctly from `updatecli/policies/autodiscovery/pyproject/`
- [ ] Verify crawler name is `pyproject` in rendered output
- [ ] Confirm SCM templates render correctly for each backend
- [ ] Test with a repository containing `pyproject.toml` files