### PR TITLE
fix: replace archived Github Action

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,14 +18,14 @@ jobs:
         uses: updatecli/releasepost-action@864390bddae97db06ee881ab4a08d159b4464643 # v0.5.0
       - name: Validate
         run: make test
-      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         # Only run e2e tests from the main branch as we need some credentials
         # that we don't want to risk leaking from pullrequest opened by random contributors
         if: github.ref == 'refs/heads/main'
         id: generate_testing_token
         with:
-          app_id: ${{ secrets.UPDATECLIBOT_TESTING_APP_ID }}
-          private_key: ${{ secrets.UPDATECLIBOT_TESTING_APP_PRIVKEY }}
+          client-id: ${{ secrets.UPDATECLIBOT_TESTING_APP_CLIENT_ID }}
+          private-key: ${{ secrets.UPDATECLIBOT_TESTING_APP_PRIVKEY }}
       - name: e2e tests
         # Only run e2e tests from the main branch as we need some credentials
         # that we don't want to risk leaking from pullrequest opened by random contributors


### PR DESCRIPTION
Replace the archived Github Action `tibdex/github-app-token` with the
maintained `actions/create-github-app-token`

*NOTE:* the maintained action prefers the `App Client ID` instead of the `App ID`, hence I also changed the name of the secret. Before merging this PR, configure the secret with the correct Github App Client ID!