### PR TITLE
chore(policy/updatecli/gha): set conditional target execution

### DIFF
--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -16,7 +16,7 @@ policies:
     policy: ghcr.io/updatecli/policies/updatecli/githubaction:0.8.1@sha256:48872bbf1a09cfff32ff5ffa07086c20b40d6888c19c36048b18f84bbdad37fe
 
   - name: Update Updatecli policies
-    policy: ghcr.io/updatecli/policies/updatecli/autodiscovery:0.8.1@sha256:f8edda1a6cbf0d7274e2b847ede29fc4dc70dd5302ccb8575ae21b069cc0d8a
+    policy: ghcr.io/updatecli/policies/updatecli/autodiscovery:0.8.1@sha256:f8edda1a6cbf0d7274e2b847ede29fc4dc70dd5302ccb8575ae21b069cc0d8a0
 
   - name: Handle GitHub action version update
-    policy: ghcr.io/updatecli/policies/autodiscovery/githubaction:0.4.1@sha256:869b676074f9fee7edd5d488140a12c3b09a5f8a175f12f26ea85a4f8bd0
+    policy: ghcr.io/updatecli/policies/autodiscovery/githubaction:0.4.1@sha256:869b676074f9fee7edd5d488140a12c3b09a5f8a175f12f26ea85a4f8bd0a9d1

--- a/updatecli/policies/updatecli/githubaction/CHANGELOG.md
+++ b/updatecli/policies/updatecli/githubaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0
+
+* Only run target if Updatecli version is detected in a GitHub action workflow
+
 ## 0.8.1
 
 * Use `kindIs "int"` to conditionally render `limit` in githubsearch SCM template, fixing broken behavior when `limit` is set to `0`

--- a/updatecli/policies/updatecli/githubaction/Policy.yaml
+++ b/updatecli/policies/updatecli/githubaction/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/updatecli/policies/"
 documentation: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/githubaction/README.md"
 changelog: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/githubaction/CHANGELOG.md"
 source: "https://github.com/updatecli/policies/tree/main/updatecli/policies/updatecli/githubaction/"
-version: 0.8.1
+version: 0.9.0
 vendor: Updatecli Project
 
 licenses:

--- a/updatecli/policies/updatecli/githubaction/updatecli.d/action-version.yaml
+++ b/updatecli/policies/updatecli/githubaction/updatecli.d/action-version.yaml
@@ -1,30 +1,45 @@
-name : 'deps: Updatecli version used by GitHub action'
-pipelineid: '{{ .pipelineid }}'
+name: "deps: Updatecli version used by GitHub action"
+pipelineid: "{{ .pipelineid }}"
 version: v0.103.0
 
 sources:
-    updatecli:
-        name: "Get latest Updatecli version"
-        kind: "githubrelease"
-        spec:
-            owner: "updatecli"
-            repository: "updatecli"
-            token: '{{ default ( env .github.env_token ) .github.token }}'
-            username: '{{ default ( env .github.env_username ) .github.username }}'
-            versionfilter:
-                kind: "semver"
-                pattern: '{{ .versionpattern }}'
+  updatecli:
+    name: "Get latest Updatecli version"
+    kind: "githubrelease"
+    spec:
+      owner: "updatecli"
+      repository: "updatecli"
+      token: "{{ default ( env .github.env_token ) .github.token }}"
+      username: "{{ default ( env .github.env_username ) .github.username }}"
+      versionfilter:
+        kind: "semver"
+        pattern: "{{ .versionpattern }}"
+
+conditions:
+  githubaction:
+    name: "Is Updatecli is used in a GitHub Action workflow"
+    kind: yaml
+    spec:
+      engine: yamlpath
+      files:
+        - ".github/workflows/*"
+      key: '$.jobs.*.steps[?(@.uses =~ /^updatecli\/updatecli-action/)].with.version'
+      keyonly: true
+      searchpattern: true
+    # {{ if .scm.enabled }}
+    scmid: default
+    # {{ end }}
 
 targets:
-    githubaction:
-        name: 'deps: update Updatecli used by Github Action to {{ source "updatecli" }}'
-        kind: yaml
-        spec:
-            engine: yamlpath 
-            key: '$.jobs.*.steps[?(@.uses =~ /^updatecli\/updatecli-action/)].with.version'
-            files:
-             - '.github/workflows/*'
-            searchpattern: true
-# {{ if .scm.enabled }}
-        scmid: default
-# {{ end }}
+  githubaction:
+    name: 'deps: update Updatecli used by Github Action to {{ source "updatecli" }}'
+    kind: yaml
+    spec:
+      engine: yamlpath
+      key: '$.jobs.*.steps[?(@.uses =~ /^updatecli\/updatecli-action/)].with.version'
+      files:
+        - ".github/workflows/*"
+      searchpattern: true
+    # {{ if .scm.enabled }}
+    scmid: default
+    # {{ end }}


### PR DESCRIPTION
Minor improvement to only execute the target if gha worfkow using Updatecli version have been detected.
This prevent this workflow to be reported as failing if Updatecli is not used on a repository.

## Test

To test this pull request, you can run the following commands:

```shell
cd updatecli/policies/updatecli/githubaction/
updatecli diff --config updatecli.d --values values.yaml --values testdata/values.yaml
```

## Additional Information

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
